### PR TITLE
chore: update workflow references

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   gitlab-dev-deploy:
     if: ${{ github.event.registry_package.package_version.container_metadata.tag.name == 'development' }}
-    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@1.0.1
+    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@1.0.2
     with:
       gitlab-project-id: '1824'
       gitlab-project-ref: 'master'

--- a/.github/workflows/pr_check_tests.yml
+++ b/.github/workflows/pr_check_tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run_tests:
-    uses: epam/ai-dial-ci/.github/workflows/test_python_docker.yml@1.0.1
+    uses: epam/ai-dial-ci/.github/workflows/test_python_docker.yml@1.0.2
     with:
       bypass_checks: false
       python_version: 3.11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,5 +9,5 @@ env:
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/publish_python_docker.yml@1.0.1
+    uses: epam/ai-dial-ci/.github/workflows/publish_python_docker.yml@1.0.2
     secrets: inherit


### PR DESCRIPTION
This PR:
- fixes release notes generation for newly-created `release-*` branches