### PR TITLE
fix: fixed bug with conflicting "model" fields in the request

### DIFF
--- a/aidial_adapter_openai/app.py
+++ b/aidial_adapter_openai/app.py
@@ -165,12 +165,11 @@ async def chat_completion(deployment_id: str, request: Request):
 
     response = await handle_exceptions(
         ChatCompletion().acreate(
-            **request_args,
             api_key=api_key,
             api_type=api_type,
             api_version=api_version,
             request_timeout=DEFAULT_TIMEOUT,
-            **data,
+            **(data | request_args),
         )
     )
 
@@ -215,12 +214,11 @@ async def embedding(deployment_id: str, request: Request):
 
     return await handle_exceptions(
         Embedding().acreate(
-            **request_args,
             api_key=api_key,
             api_type=api_type,
             api_version=api_version,
             request_timeout=DEFAULT_TIMEOUT,
-            **data,
+            **(data | request_args),
         )
     )
 

--- a/aidial_adapter_openai/databricks.py
+++ b/aidial_adapter_openai/databricks.py
@@ -28,11 +28,10 @@ async def chat_completion(
     ).prepare_request_args(deployment_id)
 
     response = await ChatCompletion().acreate(
-        **request_args,
         api_type=api_type,
         api_key=api_key,
         request_timeout=DEFAULT_TIMEOUT,
-        **data,
+        **(data | request_args),
     )
 
     if isinstance(response, AsyncIterator):


### PR DESCRIPTION
When the incoming request has `model` field, it must be overwritten with the `model` field, which we derive from the deployment id.

Fixes #95 