### PR TITLE
fix: fixed Azure AD tokens issuing logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Copy `.env.example` to `.env` and customize it for your environment:
 |DALLE3_DEPLOYMENTS|``|Comma-separated list of deployments that support DALL-E 3 API. Example: `dall-e-3,dalle3,dall-e`|
 |GPT4_VISION_DEPLOYMENTS|``|Comma-separated list of deployments that support GPT-4V API. Example: `gpt-4-vision-preview,gpt-4-vision`|
 |GPT4_VISION_MAX_TOKENS|1024|Default value of `max_tokens` parameter for GPT-4V when it wasn't provided in the request|
-|ACCESS_TOKEN_EXPIRATION_WINDOW|10|Expiration window of access token in seconds|
+|ACCESS_TOKEN_EXPIRATION_WINDOW|10|The Azure access token is renewed this many seconds before its actual expiration time. The buffer ensures that the token does not expire in the middle of an operation due to processing time and potential network delays.|
 |AZURE_OPEN_AI_SCOPE|https://cognitiveservices.azure.com/.default|Provided scope of access token to Azure OpenAI services|
 |API_VERSIONS_MAPPING|`{}`|The mapping of versions API for requests to Azure OpenAI API. Example: `{"2023-03-15-preview": "2023-05-15", "": "2024-02-15-preview"}`. An empty key sets the default api version for the case when the user didn't pass it in the request|
 |DALLE3_AZURE_API_VERSION|2024-02-01|The version API for requests to Azure DALL-E-3 API|

--- a/aidial_adapter_openai/utils/auth.py
+++ b/aidial_adapter_openai/utils/auth.py
@@ -23,10 +23,13 @@ AZURE_OPEN_AI_SCOPE: str = os.getenv(
 
 
 async def get_api_key() -> str:
-    now = int(time.time()) - EXPIRATION_WINDOW_IN_SEC
+    now = int(time.time())
     global access_token
 
-    if access_token is None or now > access_token.expires_on:
+    if (
+        access_token is None
+        or now + EXPIRATION_WINDOW_IN_SEC > access_token.expires_on
+    ):
         try:
             access_token = await default_credential.get_token(
                 AZURE_OPEN_AI_SCOPE


### PR DESCRIPTION
The current handling of `EXPIRATION_WINDOW_IN_SEC` isn't working as expected.

It delays the renewal of an access token by `EXPIRATION_WINDOW_IN_SEC` seconds after the token expiration time, meaning that there is a window of `EXPIRATION_WINDOW_IN_SEC` seconds when expired token is returned, which leads to occasinal 401 errors.