### PR TITLE
feat: avoid computing token usage if upstream model has reported it already

### DIFF
--- a/aidial_adapter_openai/completions.py
+++ b/aidial_adapter_openai/completions.py
@@ -30,7 +30,7 @@ def convert_to_chat_completions_response(
     converted_chunk = build_chunk(
         id=chunk.id,
         finish_reason=chunk.choices[0].finish_reason,
-        delta={
+        message={
             "content": sanitize_text(chunk.choices[0].text),
             "role": "assistant",
         },

--- a/aidial_adapter_openai/gpt.py
+++ b/aidial_adapter_openai/gpt.py
@@ -56,15 +56,16 @@ async def gpt_chat_completion(
 
     if isinstance(response, AsyncStream):
 
-        prompt_tokens = tokenizer.calculate_prompt_tokens(data["messages"])
         return StreamingResponse(
             to_openai_sse_stream(
                 generate_stream(
-                    prompt_tokens,
-                    map_stream(chunk_to_dict, response),
-                    tokenizer,
-                    deployment_id,
-                    discarded_messages,
+                    get_prompt_tokens=lambda: tokenizer.calculate_prompt_tokens(
+                        data["messages"]
+                    ),
+                    tokenize=tokenizer.calculate_tokens,
+                    deployment=deployment_id,
+                    discarded_messages=discarded_messages,
+                    stream=map_stream(chunk_to_dict, response),
                 ),
             ),
             media_type="text/event-stream",

--- a/aidial_adapter_openai/gpt4_multi_modal/chat_completion.py
+++ b/aidial_adapter_openai/gpt4_multi_modal/chat_completion.py
@@ -232,14 +232,14 @@ async def chat_completion(
                 map_stream(
                     debug_print,
                     generate_stream(
+                        get_prompt_tokens=lambda: estimated_prompt_tokens,
+                        tokenize=tokenizer.calculate_tokens,
+                        deployment=deployment,
+                        discarded_messages=None,
                         stream=map_stream(
                             response_transformer,
                             parse_openai_sse_stream(response),
                         ),
-                        prompt_tokens=estimated_prompt_tokens,
-                        tokenizer=tokenizer,
-                        deployment=deployment,
-                        discarded_messages=None,
                     ),
                 )
             ),

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -11,7 +11,7 @@ def assert_equal(actual, expected):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_streaming(test_app: httpx.AsyncClient):
+async def test_streaming_computed_tokens(test_app: httpx.AsyncClient):
     mock_stream = OpenAIStream(
         {
             "id": "chatcmpl-test",
@@ -87,3 +87,82 @@ async def test_streaming(test_app: httpx.AsyncClient):
             }
         },
     )
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_streaming_inherited_tokens(test_app: httpx.AsyncClient):
+    mock_stream = OpenAIStream(
+        {
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "created": 1695940483,
+            "model": "gpt-4",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": None,
+                    "delta": {
+                        "role": "assistant",
+                    },
+                }
+            ],
+            "usage": None,
+        },
+        {
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "created": 1695940483,
+            "model": "gpt-4",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": None,
+                    "delta": {
+                        "content": "Test content",
+                    },
+                }
+            ],
+        },
+        {
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "created": 1696245654,
+            "model": "gpt-4",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "delta": {},
+                }
+            ],
+            "usage": {
+                "completion_tokens": 111,
+                "prompt_tokens": 222,
+                "total_tokens": 333,
+            },
+        },
+    )
+
+    respx.post(
+        "http://localhost:5001/openai/deployments/gpt-4/chat/completions?api-version=2023-06-15"
+    ).respond(
+        status_code=200,
+        content=mock_stream.to_content(),
+        content_type="text/event-stream",
+    )
+
+    response = await test_app.post(
+        "/openai/deployments/gpt-4/chat/completions?api-version=2023-06-15",
+        json={
+            "messages": [{"role": "user", "content": "Test content"}],
+            "stream": True,
+        },
+        headers={
+            "X-UPSTREAM-KEY": "TEST_API_KEY",
+            "X-UPSTREAM-ENDPOINT": "http://localhost:5001/openai/deployments/gpt-4/chat/completions",
+        },
+    )
+
+    assert response.status_code == 200
+    mock_stream.assert_response_content(response, assert_equal)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -2,7 +2,7 @@ import httpx
 import pytest
 import respx
 
-from tests.utils.stream import OpenAIStream
+from tests.utils.stream import OpenAIStream, single_choice_chunk
 
 
 def assert_equal(actual, expected):
@@ -13,46 +13,9 @@ def assert_equal(actual, expected):
 @pytest.mark.asyncio
 async def test_streaming_computed_tokens(test_app: httpx.AsyncClient):
     mock_stream = OpenAIStream(
-        {
-            "id": "chatcmpl-test",
-            "object": "chat.completion.chunk",
-            "created": 1695940483,
-            "model": "gpt-4",
-            "choices": [
-                {
-                    "index": 0,
-                    "finish_reason": None,
-                    "delta": {
-                        "role": "assistant",
-                    },
-                }
-            ],
-            "usage": None,
-        },
-        {
-            "id": "chatcmpl-test",
-            "object": "chat.completion.chunk",
-            "created": 1695940483,
-            "model": "gpt-4",
-            "choices": [
-                {
-                    "index": 0,
-                    "finish_reason": None,
-                    "delta": {
-                        "content": "Test content",
-                    },
-                }
-            ],
-            "usage": None,
-        },
-        {
-            "id": "chatcmpl-test",
-            "object": "chat.completion.chunk",
-            "created": 1696245654,
-            "model": "gpt-4",
-            "choices": [{"index": 0, "finish_reason": "stop", "delta": {}}],
-            "usage": None,
-        },
+        single_choice_chunk(delta={"role": "assistant"}),
+        single_choice_chunk(delta={"content": "Test content"}),
+        single_choice_chunk(delta={}, finish_reason="stop"),
     )
 
     respx.post(
@@ -93,55 +56,17 @@ async def test_streaming_computed_tokens(test_app: httpx.AsyncClient):
 @pytest.mark.asyncio
 async def test_streaming_inherited_tokens(test_app: httpx.AsyncClient):
     mock_stream = OpenAIStream(
-        {
-            "id": "chatcmpl-test",
-            "object": "chat.completion.chunk",
-            "created": 1695940483,
-            "model": "gpt-4",
-            "choices": [
-                {
-                    "index": 0,
-                    "finish_reason": None,
-                    "delta": {
-                        "role": "assistant",
-                    },
-                }
-            ],
-            "usage": None,
-        },
-        {
-            "id": "chatcmpl-test",
-            "object": "chat.completion.chunk",
-            "created": 1695940483,
-            "model": "gpt-4",
-            "choices": [
-                {
-                    "index": 0,
-                    "finish_reason": None,
-                    "delta": {
-                        "content": "Test content",
-                    },
-                }
-            ],
-        },
-        {
-            "id": "chatcmpl-test",
-            "object": "chat.completion.chunk",
-            "created": 1696245654,
-            "model": "gpt-4",
-            "choices": [
-                {
-                    "index": 0,
-                    "finish_reason": "stop",
-                    "delta": {},
-                }
-            ],
-            "usage": {
+        single_choice_chunk(delta={"role": "assistant"}),
+        single_choice_chunk(delta={"content": "Test content"}),
+        single_choice_chunk(
+            delta={},
+            finish_reason="stop",
+            usage={
                 "completion_tokens": 111,
                 "prompt_tokens": 222,
                 "total_tokens": 333,
             },
-        },
+        ),
     )
 
     respx.post(

--- a/tests/utils/stream.py
+++ b/tests/utils/stream.py
@@ -43,3 +43,49 @@ class OpenAIStream:
                 assert False
 
             line_idx += 1
+
+
+def chunk(
+    *,
+    id: str = "chatcmpl-test",
+    created: str = "1695940483",
+    model: str = "gpt-4",
+    choices: List[dict],
+    usage: dict | None = None,
+    **kwargs,
+) -> dict:
+    return {
+        "id": id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": model,
+        "choices": choices,
+        "usage": usage,
+        **kwargs,
+    }
+
+
+def single_choice_chunk(
+    *,
+    id: str = "chatcmpl-test",
+    created: str = "1695940483",
+    model: str = "gpt-4",
+    finish_reason: str | None = None,
+    delta: dict = {},
+    usage: dict | None = None,
+    **kwargs,
+) -> dict:
+    return chunk(
+        id=id,
+        created=created,
+        model=model,
+        choices=[
+            {
+                "index": 0,
+                "finish_reason": finish_reason,
+                "delta": delta,
+            }
+        ],
+        usage=usage,
+        **kwargs,
+    )


### PR DESCRIPTION
The fix allows to use upstream models which are able to report usages in streaming mode _(e.g. the one from bedrock/vertexai adapter)_ without token counting issues.