### PR TITLE
fix: changed type of created field in chunk from str to int

### DIFF
--- a/aidial_adapter_openai/completions.py
+++ b/aidial_adapter_openai/completions.py
@@ -34,7 +34,7 @@ def convert_to_chat_completions_response(
             "content": sanitize_text(chunk.choices[0].text),
             "role": "assistant",
         },
-        created=str(chunk.created),
+        created=chunk.created,
         is_stream=is_stream,
         usage=chunk.usage.to_dict() if chunk.usage else None,
     )

--- a/aidial_adapter_openai/dalle3.py
+++ b/aidial_adapter_openai/dalle3.py
@@ -68,7 +68,7 @@ def build_custom_content(base64_image: str, revised_prompt: str) -> Any:
 
 
 async def generate_stream(
-    id: str, created: str, custom_content: Any
+    id: str, created: int, custom_content: Any
 ) -> AsyncIterator[dict]:
     yield build_chunk(id, None, {"role": "assistant"}, created, True)
     yield build_chunk(id, None, custom_content, created, True)

--- a/aidial_adapter_openai/utils/streaming.py
+++ b/aidial_adapter_openai/utils/streaming.py
@@ -20,18 +20,22 @@ fix_streaming_issues_in_new_api_versions = get_env_bool(
 )
 
 
-def generate_id():
+def generate_id() -> str:
     return "chatcmpl-" + str(uuid4())
+
+
+def generate_created() -> int:
+    return int(time())
 
 
 def build_chunk(
     id: str,
     finish_reason: Optional[str],
     message: Any,
-    created: str,
+    created: int,
     is_stream: bool,
     **extra,
-):
+) -> dict:
     message_key = "delta" if is_stream else "message"
     object_name = "chat.completion.chunk" if is_stream else "chat.completion"
 
@@ -120,7 +124,7 @@ async def generate_stream(
 
         last_chunk = last_chunk or {}
         id = last_chunk.get("id") or generate_id()
-        created = last_chunk.get("created") or str(int(time()))
+        created = last_chunk.get("created") or generate_created()
         model = last_chunk.get("model") or deployment
 
         finish_chunk = build_chunk(
@@ -139,7 +143,7 @@ async def generate_stream(
 
 def create_stage_chunk(name: str, content: str, stream: bool) -> dict:
     id = generate_id()
-    created = str(int(time()))
+    created = generate_created()
 
     stage = {
         "index": 0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,10 @@ flake8 = "6.0.0"
 nox = "^2023.4.22"
 
 [tool.pytest.ini_options]
-# muting warnings coming from opentelemetry package
+# muting warnings coming from opentelemetry and pkg_resources packages
 filterwarnings = [
-    "ignore::DeprecationWarning:opentelemetry.instrumentation.dependencies"
+    "ignore::DeprecationWarning:opentelemetry.instrumentation.dependencies",
+    "ignore::DeprecationWarning:pkg_resources"
 ]
 
 [tool.pyright]

--- a/tests/utils/dictionary.py
+++ b/tests/utils/dictionary.py
@@ -1,0 +1,5 @@
+from typing import Iterable
+
+
+def exclude_keys(d: dict, keys: Iterable[str]) -> dict:
+    return {k: v for k, v in d.items() if k not in keys}

--- a/tests/utils/stream.py
+++ b/tests/utils/stream.py
@@ -48,7 +48,7 @@ class OpenAIStream:
 def chunk(
     *,
     id: str = "chatcmpl-test",
-    created: str = "1695940483",
+    created: int = 1695940483,
     model: str = "gpt-4",
     choices: List[dict],
     usage: dict | None = None,
@@ -68,7 +68,7 @@ def chunk(
 def single_choice_chunk(
     *,
     id: str = "chatcmpl-test",
-    created: str = "1695940483",
+    created: int = 1695940483,
     model: str = "gpt-4",
     finish_reason: str | None = None,
     delta: dict = {},


### PR DESCRIPTION
`created` is [expected](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-07-01-preview/inference.yaml#L3736-L3739) to be an integer field