### PR TITLE
fix: disabled retries in openai client

### DIFF
--- a/aidial_adapter_openai/utils/parsers.py
+++ b/aidial_adapter_openai/utils/parsers.py
@@ -36,6 +36,7 @@ class AzureOpenAIEndpoint(BaseModel):
             azure_ad_token=params.get("azure_ad_token"),
             api_version=params.get("api_version"),
             timeout=params.get("timeout"),
+            max_retries=0,
             http_client=get_http_client(),
         )
 
@@ -48,6 +49,7 @@ class OpenAIEndpoint(BaseModel):
             base_url=self.base_url,
             api_key=params.get("api_key"),
             timeout=params.get("timeout"),
+            max_retries=0,
             http_client=get_http_client(),
         )
 

--- a/aidial_adapter_openai/utils/parsers.py
+++ b/aidial_adapter_openai/utils/parsers.py
@@ -24,6 +24,10 @@ class Endpoint(ABC):
         pass
 
 
+# Retries are handled on the DIAL Core side
+_MAX_RETRIES = 0
+
+
 class AzureOpenAIEndpoint(BaseModel):
     azure_endpoint: str
     azure_deployment: str
@@ -36,7 +40,7 @@ class AzureOpenAIEndpoint(BaseModel):
             azure_ad_token=params.get("azure_ad_token"),
             api_version=params.get("api_version"),
             timeout=params.get("timeout"),
-            max_retries=0,
+            max_retries=_MAX_RETRIES,
             http_client=get_http_client(),
         )
 
@@ -49,7 +53,7 @@ class OpenAIEndpoint(BaseModel):
             base_url=self.base_url,
             api_key=params.get("api_key"),
             timeout=params.get("timeout"),
-            max_retries=0,
+            max_retries=_MAX_RETRIES,
             http_client=get_http_client(),
         )
 


### PR DESCRIPTION
`openai<1` didn't have buildin retries.

`openai>=1` did introduce retries with [default number of retries equal 2](https://github.com/openai/openai-python/blob/05fa732c024b55ddda1f5f8b107ce78233acd3ce/src/openai/_constants.py#L10).

[Migration](https://github.com/epam/ai-dial-adapter-openai/pull/105) to `openai>=1` has unintentionally introduced retries to the [adapter-openai>=0.13.0](https://github.com/epam/ai-dial-adapter-openai/releases/tag/0.13.0).

This fix disables retries, since they are already [handled by DIAL Core](https://github.com/epam/ai-dial-core/blob/f4c6c95c5469fa0481f1e672643959f09e284e3d/src/main/java/com/epam/aidial/core/controller/DeploymentPostController.java#L60-L62).