### PR TITLE
fix: fixed incorrect calculation of image tokens for GTP-4o mini models

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Copy `.env.example` to `.env` and customize it for your environment.
 
 ### Categories of deployments
 
-The following variables cluster all deployments into the groups of deployments which share the same API.
+The following variables cluster all deployments into the groups of deployments which share the same API and the same tokenization algorithm.
 
 |Variable|Default|Description|
 |---|---|---|
@@ -73,6 +73,7 @@ The following variables cluster all deployments into the groups of deployments w
 |MISTRAL_DEPLOYMENTS|``|Comma-separated list of deployments that support Mistral Large Azure API. Example: `mistral-large-azure,mistral-large`|
 |DATABRICKS_DEPLOYMENTS|``|Comma-separated list of Databricks chat completion deployments. Example: `databricks-dbrx-instruct,databricks-mixtral-8x7b-instruct,databricks-llama-2-70b-chat`|
 |GPT4O_DEPLOYMENTS|``|Comma-separated list of GPT-4o chat completion deployments. Example: `gpt-4o-2024-05-13`|
+|GPT4O_MINI_DEPLOYMENTS|``|Comma-separated list of GPT-4o mini chat completion deployments. Example: `gpt-4o-mini-2024-07-18`|
 |AZURE_AI_VISION_DEPLOYMENTS|``|Comma-separated list of Azure AI Vision embedding deployments. The endpoint of the deployment is expected point to the Azure service: `https://<service-name>.cognitiveservices.azure.com/`|
 
 Deployments that do not fall into any of the categories are considered to support text-to-text chat completion OpenAI API or text embeddings OpenAI API.

--- a/aidial_adapter_openai/env.py
+++ b/aidial_adapter_openai/env.py
@@ -16,6 +16,9 @@ DATABRICKS_DEPLOYMENTS = parse_deployment_list(
     os.getenv("DATABRICKS_DEPLOYMENTS")
 )
 GPT4O_DEPLOYMENTS = parse_deployment_list(os.getenv("GPT4O_DEPLOYMENTS"))
+GPT4O_MINI_DEPLOYMENTS = parse_deployment_list(
+    os.getenv("GPT4O_MINI_DEPLOYMENTS")
+)
 API_VERSIONS_MAPPING: Dict[str, str] = json.loads(
     os.getenv("API_VERSIONS_MAPPING", "{}")
 )

--- a/aidial_adapter_openai/gpt4_multi_modal/chat_completion.py
+++ b/aidial_adapter_openai/gpt4_multi_modal/chat_completion.py
@@ -163,6 +163,7 @@ async def gpt4_vision_chat_completion(
     is_stream: bool,
     file_storage: Optional[FileStorage],
     api_version: str,
+    tokenizer: MultiModalTokenizer,
 ):
     return await chat_completion(
         request,
@@ -172,7 +173,7 @@ async def gpt4_vision_chat_completion(
         is_stream,
         file_storage,
         api_version,
-        MultiModalTokenizer("gpt-4"),
+        tokenizer,
         convert_gpt4v_to_gpt4_chunk,
         GPT4V_DEFAULT_MAX_TOKENS,
     )

--- a/aidial_adapter_openai/utils/image.py
+++ b/aidial_adapter_openai/utils/image.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from typing import Literal
+from typing import Literal, assert_never
 
 from PIL import Image
 from pydantic import BaseModel
@@ -21,6 +21,8 @@ def resolve_detail_level(
             return "low"
         case "high":
             return "high"
+        case _:
+            assert_never(detail)
 
 
 class ImageMetadata(BaseModel):

--- a/aidial_adapter_openai/utils/image_tokenizer.py
+++ b/aidial_adapter_openai/utils/image_tokenizer.py
@@ -1,45 +1,78 @@
 """
 Tokenization of images as specified at
-    https://learn.microsoft.com/en-us/azure/ai-services/openai/overview#image-tokens-gpt-4-turbo-with-vision
+    https://learn.microsoft.com/en-us/azure/ai-services/openai/overview#image-tokens
 """
 
-import base64
 import math
-from io import BytesIO
-from typing import assert_never
+from typing import List, Tuple, assert_never
 
-from PIL import Image
+from pydantic import BaseModel
 
+from aidial_adapter_openai.env import (
+    GPT4_VISION_DEPLOYMENTS,
+    GPT4O_DEPLOYMENTS,
+    GPT4O_MINI_DEPLOYMENTS,
+)
 from aidial_adapter_openai.utils.image import ImageDetail, resolve_detail_level
-from aidial_adapter_openai.utils.resource import Resource
 
 
-def tokenize_image_data_url(image_data: str, detail: ImageDetail) -> int:
-    parsed_image_data = Resource.from_data_url(image_data)
-    if not parsed_image_data:
-        raise ValueError(f"Invalid image data URL {parsed_image_data!r}")
-    return tokenize_image(parsed_image_data, detail)
+class ImageTokenizer(BaseModel):
+    low_detail_tokens: int
+    """
+    Number of tokens per image in low resolution mode
+    """
+
+    tokens_per_tile: int
+    """
+    Number of tokens per one tile image of 512x512 size
+    """
+
+    def tokenize(self, width: int, height: int, detail: ImageDetail) -> int:
+        concrete_detail = resolve_detail_level(width, height, detail)
+        match concrete_detail:
+            case "low":
+                return self.low_detail_tokens
+            case "high":
+                return self._compute_high_detail_tokens(width, height)
+            case _:
+                assert_never(concrete_detail)
+
+    def _compute_high_detail_tokens(self, width: int, height: int) -> int:
+        # Fit into 2048x2048 box
+        width, height = _fit_longest(width, height, 2048)
+
+        # Scale down so the shortest side is 768 pixels
+        width, height = _fit_shortest(width, height, 768)
+
+        # Calculate the number of 512-pixel tiles required
+        cols = math.ceil(width / 512)
+        rows = math.ceil(height / 512)
+
+        return (self.tokens_per_tile * cols * rows) + self.low_detail_tokens
 
 
-def tokenize_image(image: Resource, detail: ImageDetail) -> int:
-    image_data = base64.b64decode(image.data)
-    with Image.open(BytesIO(image_data)) as img:
-        width, height = img.size
-        return tokenize_image_by_size(width, height, detail)
+GPT4O_IMAGE_TOKENIZER = GPT4_VISION_IMAGE_TOKENIZER = ImageTokenizer(
+    low_detail_tokens=85, tokens_per_tile=170
+)
+GPT4O_MINI_IMAGE_TOKENIZER = ImageTokenizer(
+    low_detail_tokens=2833, tokens_per_tile=5667
+)
+
+_TOKENIZERS: List[Tuple[ImageTokenizer, List[str]]] = [
+    (GPT4O_IMAGE_TOKENIZER, GPT4O_DEPLOYMENTS),
+    (GPT4O_MINI_IMAGE_TOKENIZER, GPT4O_MINI_DEPLOYMENTS),
+    (GPT4_VISION_IMAGE_TOKENIZER, GPT4_VISION_DEPLOYMENTS),
+]
 
 
-def tokenize_image_by_size(width: int, height: int, detail: ImageDetail) -> int:
-    concrete_detail = resolve_detail_level(width, height, detail)
-    match concrete_detail:
-        case "low":
-            return 85
-        case "high":
-            return compute_high_detail_tokens(width, height)
-        case _:
-            assert_never(concrete_detail)
+def get_image_tokenizer(deployment_id: str) -> ImageTokenizer | None:
+    for tokenizer, ids in _TOKENIZERS:
+        if deployment_id in ids:
+            return tokenizer
+    return None
 
 
-def fit_longest(width: int, height: int, size: int) -> tuple[int, int]:
+def _fit_longest(width: int, height: int, size: int) -> tuple[int, int]:
     ratio = width / height
     if width > height:
         scaled_width = min(width, size)
@@ -51,7 +84,7 @@ def fit_longest(width: int, height: int, size: int) -> tuple[int, int]:
     return scaled_width, scaled_height
 
 
-def fit_shortest(width: int, height: int, size: int) -> tuple[int, int]:
+def _fit_shortest(width: int, height: int, size: int) -> tuple[int, int]:
     ratio = width / height
     if width < height:
         scaled_width = min(width, size)
@@ -61,17 +94,3 @@ def fit_shortest(width: int, height: int, size: int) -> tuple[int, int]:
         scaled_width = int(scaled_height * ratio)
 
     return scaled_width, scaled_height
-
-
-def compute_high_detail_tokens(width: int, height: int) -> int:
-    # Fit into 2048x2048 box
-    width, height = fit_longest(width, height, 2048)
-
-    # Scale down so the shortest side is 768 pixels
-    width, height = fit_shortest(width, height, 768)
-
-    # Calculate the number of 512-pixel tiles required
-    cols = math.ceil(width / 512)
-    rows = math.ceil(height / 512)
-
-    return (170 * cols * rows) + 85

--- a/poetry.lock
+++ b/poetry.lock
@@ -1888,6 +1888,20 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
+name = "python-dotenv"
+version = "1.0.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
+    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "pywin32"
 version = "306"
 description = "Python for Window Extensions"
@@ -2423,4 +2437,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "b1067d000d1df095ededd79f4683fe0251b689abf8b1f16b4219bd0814bd8983"
+content-hash = "b5ce5e84cdb97ccf9d9bd43fb5879a78e3da57b71403739b08c351ad85a27cf1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ flake8 = "6.0.0"
 
 [tool.poetry.group.dev.dependencies]
 nox = "^2023.4.22"
+# Required for `make serve` which loads .env file
+python-dotenv = "^1.0.1"
 
 [tool.pytest.ini_options]
 # muting warnings coming from opentelemetry and pkg_resources packages

--- a/tests/test_image_tokenization.py
+++ b/tests/test_image_tokenization.py
@@ -3,7 +3,7 @@ from typing import List, Tuple
 import pytest
 
 from aidial_adapter_openai.utils.image import ImageDetail
-from aidial_adapter_openai.utils.image_tokenizer import tokenize_image_by_size
+from aidial_adapter_openai.utils.image_tokenizer import GPT4O_IMAGE_TOKENIZER
 
 test_cases: List[Tuple[int, int, ImageDetail, int]] = [
     (1, 1, "auto", 85),
@@ -25,8 +25,8 @@ test_cases: List[Tuple[int, int, ImageDetail, int]] = [
 
 @pytest.mark.parametrize("width, height, detail, expected_tokens", test_cases)
 def test_tokenize(width, height, detail, expected_tokens):
-    tokens1 = tokenize_image_by_size(width, height, detail)
-    tokens2 = tokenize_image_by_size(height, width, detail)
+    tokens1 = GPT4O_IMAGE_TOKENIZER.tokenize(width, height, detail)
+    tokens2 = GPT4O_IMAGE_TOKENIZER.tokenize(height, width, detail)
 
     assert tokens1 == expected_tokens
     assert tokens2 == expected_tokens

--- a/tests/test_multimodal_truncate.py
+++ b/tests/test_multimodal_truncate.py
@@ -8,11 +8,12 @@ from aidial_adapter_openai.gpt4_multi_modal.chat_completion import (
     multi_modal_truncate_prompt,
 )
 from aidial_adapter_openai.utils.image import ImageMetadata
+from aidial_adapter_openai.utils.image_tokenizer import GPT4O_IMAGE_TOKENIZER
 from aidial_adapter_openai.utils.multi_modal_message import MultiModalMessage
 from aidial_adapter_openai.utils.resource import Resource
 from aidial_adapter_openai.utils.tokenizer import MultiModalTokenizer
 
-tokenizer = MultiModalTokenizer("gpt-4o")
+tokenizer = MultiModalTokenizer("gpt-4o", GPT4O_IMAGE_TOKENIZER)
 
 
 def test_multimodal_truncate_with_system_and_last_user_error():


### PR DESCRIPTION
Resolves https://github.com/epam/ai-dial-adapter-openai/issues/165

## Configuration changes

Added a new `GPT4O_MINI_DEPLOYMENTS` env var.

### The migration procedure 

Move **gpt-4o mini** deployments from `GPT4O_DEPLOYMENTS` to this new `GPT4O_MINI_DEPLOYMENTS` env var:

Conf before:

```
GPT4O_DEPLOYMENTS=gpt-4o-depl1,gpt-4o-depl2,gpt-4o-mini-depl1,gpt-4o-mini-depl2
```

Conf after:

```
GPT4O_DEPLOYMENTS=gpt-4o-depl1,gpt-4o-depl2
GPT4O_MINI_DEPLOYMENTS=gpt-4o-mini-depl1,gpt-4o-mini-depl2
```