### PR TITLE
fix: truncated error message in plain text tokenizer

### DIFF
--- a/aidial_adapter_openai/utils/tokenizer.py
+++ b/aidial_adapter_openai/utils/tokenizer.py
@@ -96,7 +96,7 @@ def _process_raw_message(
                 pass
             else:
                 raise InternalServerError(
-                    f"Unexpected type of content in message: {value!r}"
+                    f"Unexpected type of content in message: {type(value)}"
                 )
 
         elif key == "role":
@@ -104,7 +104,7 @@ def _process_raw_message(
                 tokens += calculate_text_tokens(value)
             else:
                 raise InternalServerError(
-                    f"Unexpected type of 'role' field in message: {value!r}"
+                    f"Unexpected type of 'role' field in message: {type(value)}"
                 )
     return tokens
 
@@ -116,8 +116,9 @@ class PlainTextTokenizer(BaseTokenizer[dict]):
     """
 
     def _handle_custom_content_part(self, content_part: Any):
+        short_content_part = str(content_part)[:100]
         raise InternalServerError(
-            f"Unexpected type of content in message: {content_part!r}"
+            f"Unexpected type of content in message: {short_content_part!r}"
             f"Use MultiModalTokenizer for messages with images"
         )
 


### PR DESCRIPTION
The non-text content parts may contain base64 encoded images, which leads to very large error messages.
The error message is truncated to 100 symbols.