### PR TITLE
fix: removed content-encoding header to avoid decoding errors

### DIFF
--- a/aidial_adapter_openai/app.py
+++ b/aidial_adapter_openai/app.py
@@ -215,10 +215,16 @@ async def embedding(deployment_id: str, request: Request):
 def openai_exception_handler(request: Request, e: DialException):
     if isinstance(e, APIStatusError):
         r = e.response
+        headers = r.headers
+
+        # Avoid encoding the error message when the original response was encoded.
+        if "Content-Encoding" in headers:
+            del headers["Content-Encoding"]
+
         return Response(
             content=r.content,
             status_code=r.status_code,
-            headers=r.headers,
+            headers=headers,
         )
 
     if isinstance(e, APITimeoutError):


### PR DESCRIPTION
See the identical PR https://github.com/epam/ai-dial-adapter-dial/pull/29 for the rationale.