### PR TITLE
fix: tolerate tokenizer failures

### DIFF
--- a/aidial_adapter_openai/utils/tokenizer.py
+++ b/aidial_adapter_openai/utils/tokenizer.py
@@ -14,6 +14,7 @@ from aidial_adapter_openai.utils.chat_completion_response import (
 )
 from aidial_adapter_openai.utils.image_tokenizer import ImageTokenizer
 from aidial_adapter_openai.utils.multi_modal_message import MultiModalMessage
+from aidial_adapter_openai.utils.text import truncate_string
 
 MessageType = TypeVar("MessageType")
 
@@ -154,10 +155,11 @@ class PlainTextTokenizer(BaseTokenizer[dict]):
     """
 
     def _handle_custom_content_part(self, content_part: Any):
-        short_content_part = str(content_part)[:100]
+        short_content_str = truncate_string(str(content_part), 100)
         raise InternalServerError(
-            f"Unexpected type of content in message: {short_content_part!r}"
-            f"Use MultiModalTokenizer for messages with images"
+            f"Unexpected non-textural content part in the request: {short_content_str!r}. "
+            f"The deployment only supports plain text messages. "
+            f"Declare the deployment as a multi-modal one in the OpenAI adapter configuration to avoid the error."
         )
 
     def tokenize_request_message(self, message: dict) -> int:


### PR DESCRIPTION
Also, improved error message for an unexpected non-textual content part.

## Motivation

The computation of the ` usage` field during streaming is the feature of the Adapter itself.

It's frustrating for an end user to see the Adapter failing on a **successful** response from the upstream only because the Adapter hasn't managed to tokenize the request/response for whatever reason _(the adapter may have a bug in the tokenization logic or the deployment was misconfigured)_.

A safer option is to allow the response to succeed without any `usage` reported, and log the error message in the Adapter.