### PR TITLE
fix: remove invalidated content-length in error response

### DIFF
--- a/aidial_adapter_openai/exception_handlers.py
+++ b/aidial_adapter_openai/exception_handlers.py
@@ -9,6 +9,7 @@ from aidial_adapter_openai.utils.adapter_exception import (
     ResponseWrapper,
     parse_adapter_exception,
 )
+from aidial_adapter_openai.utils.log_config import logger
 
 
 def to_adapter_exception(exc: Exception) -> AdapterException:
@@ -32,7 +33,7 @@ def to_adapter_exception(exc: Exception) -> AdapterException:
 
         return parse_adapter_exception(
             status_code=r.status_code,
-            headers=dict(httpx_headers.items()),
+            headers=httpx_headers,
             content=r.text,
         )
 
@@ -71,6 +72,12 @@ def to_adapter_exception(exc: Exception) -> AdapterException:
 
 
 def adapter_exception_handler(
-    request: FastAPIRequest, exc: Exception
+    request: FastAPIRequest, e: Exception
 ) -> FastAPIResponse:
-    return to_adapter_exception(exc).to_fastapi_response()
+    adapter_exception = to_adapter_exception(e)
+
+    logger.error(
+        f"Caught exception: {type(e).__module__}.{type(e).__name__}. "
+        f"Converted to the adapter exception: {adapter_exception!r}"
+    )
+    return adapter_exception.to_fastapi_response()

--- a/aidial_adapter_openai/utils/sse_stream.py
+++ b/aidial_adapter_openai/utils/sse_stream.py
@@ -60,13 +60,11 @@ async def to_openai_sse_stream(
         async for chunk in stream:
             yield format_chunk(chunk)
     except Exception as e:
-        logger.exception(
-            f"caught exception while streaming: {type(e).__module__}.{type(e).__name__}"
-        )
-
         adapter_exception = to_adapter_exception(e)
-        logger.error(
-            f"converted to the adapter exception: {adapter_exception!r}"
+
+        logger.exception(
+            f"Caught exception while streaming: {type(e).__module__}.{type(e).__name__}. "
+            f"Converted to the adapter exception: {adapter_exception!r}"
         )
 
         yield format_chunk(adapter_exception.json_error())

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -50,7 +50,7 @@ def create_test_cases(
             build_vision_common,
         ]
     ),
-    ids=lambda tc: tc.get_id(),
+    ids=lambda tc: tc.get_id() if isinstance(tc, TestCase) else "na",
 )
 async def test_chat_completion(
     test_case: TestCase,


### PR DESCRIPTION
We should not proxy `Content-Length` header from the upstream for errors that are parsed to DIAL HTTPException and then converted back to text, because this invalidates the content length.

# How to reproduce

Run in console 1:

```sh
PORT=5006 make serve      
```

Run in console 2:

```sh
while true; do echo -e "HTTP/1.1 400 Bad Request\r\nContent-Length: 49\r\nContent-Type: application/json\r\n\r\n{\"error\":{\"message\": \"Bad request\",\"code\":\"400\"}}" | nc -l 5007; done
```

Send the request in the console 3:

```sh
curl -X POST http://0.0.0.0:5006/openai/deployments/gpt-4/chat/completions?api-version=2023-03-15-preview \
  --http1.1 \
  -H "X-UPSTREAM-ENDPOINT:http://localhost:5007/openai/deployments/gpt-4/chat/completions" \
  -H "X-UPSTREAM-KEY:dummy-key" \
  -H "api-key:dummy-key" \
  -H "content-type:application/json" \
  -d '{"messages": [{"content": "test", "role": "user"}]}' \
  -v --raw
```

Finally, observe the error in the adapter (console 1):

```
  File ".venv/lib/python3.11/site-packages/h11/_connection.py", line 545, in send_with_data_passthrough
    writer(event, data_list.append)
  File ".venv/lib/python3.11/site-packages/h11/_writers.py", line 67, in __call__
    self.send_eom(event.headers, write)
  File ".venv/lib/python3.11/site-packages/h11/_writers.py", line 96, in send_eom
    raise LocalProtocolError("Too little data for declared Content-Length")
h11._util.LocalProtocolError: Too little data for declared Content-Length
```