### PR TITLE
fix: allow user-defined model field

### DIFF
--- a/aidial_adapter_openai/endpoints/chat_completion.py
+++ b/aidial_adapter_openai/endpoints/chat_completion.py
@@ -50,7 +50,7 @@ async def call_chat_completion(
     # Azure and non-Azure deployments.
     # Therefore, we provide the "model" field for all deployments here.
     # The same goes for /embeddings endpoint.
-    data["model"] = deployment_id
+    data["model"] = data.get("model") or deployment_id
 
     creds = await get_credentials(request)
     api_version = get_api_version(request)


### PR DESCRIPTION
Fix for #193, to allow user to pass custom value into "model" field, to allow value with backlash, like `openrouter/auto` value, that is forbidden inside URL
