### PR TITLE
fix: fix error handling for multi-modal GPT4 models

### DIFF
--- a/aidial_adapter_openai/app_config.py
+++ b/aidial_adapter_openai/app_config.py
@@ -46,11 +46,17 @@ class ApplicationConfig(BaseModel):
 
     def add_deployment(
         self, deployment_id: str, deployment_type: ChatCompletionDeploymentType
-    ):
-        if deployment_type == ChatCompletionDeploymentType.GPT_TEXT_ONLY:
-            return
-        config_getter = self.DEPLOYMENT_TYPE_MAP[deployment_type]
-        config_getter(self).append(deployment_id)
+    ) -> "ApplicationConfig":
+        if deployment_type != ChatCompletionDeploymentType.GPT_TEXT_ONLY:
+            config_getter = self.DEPLOYMENT_TYPE_MAP[deployment_type]
+            config_getter(self).append(deployment_id)
+        return self
+
+    def map_to_tiktoken_model(
+        self, deployment_id: str, tiktoken_model: str
+    ) -> "ApplicationConfig":
+        self.MODEL_ALIASES[deployment_id] = tiktoken_model
+        return self
 
     @classmethod
     def from_env(cls) -> "ApplicationConfig":

--- a/aidial_adapter_openai/gpt4_multi_modal/chat_completion.py
+++ b/aidial_adapter_openai/gpt4_multi_modal/chat_completion.py
@@ -14,7 +14,7 @@ from typing import (
 import aiohttp
 from aidial_sdk.exceptions import HTTPException as DialException
 from aidial_sdk.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import Response
 
 from aidial_adapter_openai.dial_api.storage import FileStorage
 from aidial_adapter_openai.gpt4_multi_modal.gpt4_vision import (
@@ -69,6 +69,9 @@ async def transpose_stream(
     first_chunk: Optional[bytes] = None
     async for chunk in stream:
         if isinstance(chunk, Response):
+            # Exhaust the stream
+            async for _ in stream:
+                pass
             return chunk
         else:
             first_chunk = chunk
@@ -94,26 +97,27 @@ async def predict_stream_raw(
         async with session.post(
             api_url, json=request, headers=headers
         ) as response:
-            if response.status != 200:
-                yield JSONResponse(
-                    status_code=response.status, content=await response.json()
+            if not response.ok:
+                yield Response(
+                    status_code=response.status,
+                    content=await response.content.read(),
                 )
-                return
-
-            async for line in response.content:
-                yield line
+            else:
+                async for line in response.content:
+                    yield line
 
 
 async def predict_non_stream(
     api_url: str, headers: Dict[str, str], request: Any
-) -> dict | JSONResponse:
+) -> dict | Response:
     async with aiohttp.ClientSession() as session:
         async with session.post(
             api_url, json=request, headers=headers
         ) as response:
-            if response.status != 200:
-                return JSONResponse(
-                    status_code=response.status, content=await response.json()
+            if not response.ok:
+                return Response(
+                    status_code=response.status,
+                    content=await response.content.read(),
                 )
             return await response.json()
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -155,6 +155,21 @@ yarl = ">=1.12.0,<2.0"
 speedups = ["Brotli", "aiodns (>=3.2.0)", "brotlicffi"]
 
 [[package]]
+name = "aioresponses"
+version = "0.7.8"
+description = "Mock out requests made by ClientSession from aiohttp package"
+optional = false
+python-versions = "*"
+files = [
+    {file = "aioresponses-0.7.8-py2.py3-none-any.whl", hash = "sha256:b73bd4400d978855e55004b23a3a84cb0f018183bcf066a85ad392800b5b9a94"},
+    {file = "aioresponses-0.7.8.tar.gz", hash = "sha256:b861cdfe5dc58f3b8afac7b0a6973d5d7b2cb608dd0f6253d16b8ee8eaf6df11"},
+]
+
+[package.dependencies]
+aiohttp = ">=3.3.0,<4.0.0"
+packaging = ">=22.0"
+
+[[package]]
 name = "aiosignal"
 version = "1.3.1"
 description = "aiosignal: a list of registered asynchronous callbacks"
@@ -2561,4 +2576,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "ea6bc6f612d9f6171b574281aeb1074e032d44f2e1d3f1a63298a453e9dc5fa2"
+content-hash = "874d64f7daf173cfb06023beb28948f9c98271ea8abdf6ff7f108d1ad3abd592"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ pytest = "7.4.0"
 pytest-asyncio = "0.21.1"
 pytest-xdist = "^3.5.0"
 respx = "^0.21.1"
+aioresponses = "^0.7.8"
 
 [tool.poetry.group.lint.dependencies]
 pyright = "1.1.324"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
+import contextlib
+
 import httpx
 import pytest
 from httpx import ASGITransport
 from openai import AsyncAzureOpenAI
 
 from aidial_adapter_openai.app import create_app
+from aidial_adapter_openai.app_config import ApplicationConfig
 from aidial_adapter_openai.utils.http_client import DEFAULT_TIMEOUT
 from aidial_adapter_openai.utils.request import get_app_config
 from tests.integration_tests.base import DeploymentConfig
@@ -36,9 +39,20 @@ def eliminate_empty_choices(_app_instance):
     app_config.ELIMINATE_EMPTY_CHOICES = False
 
 
+@contextlib.asynccontextmanager
+async def create_test_client(app_config: ApplicationConfig):
+    app = create_app(init_telemetry=False, app_config=app_config)
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app),  # type: ignore
+        base_url="http://test-app.com",
+        timeout=DEFAULT_TIMEOUT,
+    ) as client:
+        yield client
+
+
 @pytest.fixture
-def get_openai_client(test_app: httpx.AsyncClient):
-    def _get_client(deployment_config: DeploymentConfig) -> AsyncAzureOpenAI:
+def create_openai_client(test_app: httpx.AsyncClient):
+    def _create_client(deployment_config: DeploymentConfig) -> AsyncAzureOpenAI:
         return AsyncAzureOpenAI(
             azure_endpoint=str(test_app.base_url),
             azure_deployment=deployment_config.deployment_id,
@@ -50,4 +64,4 @@ def get_openai_client(test_app: httpx.AsyncClient):
             default_headers=deployment_config.upstream_headers,
         )
 
-    yield _get_client
+    yield _create_client

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -54,9 +54,9 @@ def create_test_cases(
 )
 async def test_chat_completion(
     test_case: TestCase,
-    get_openai_client,
+    create_openai_client,
 ):
-    client = get_openai_client(test_case.deployment_config)
+    client = create_openai_client(test_case.deployment_config)
 
     async def run_chat_completion() -> ChatCompletionResult:
         for _ in range(3):

--- a/tests/unit_tests/test_errors.py
+++ b/tests/unit_tests/test_errors.py
@@ -3,9 +3,14 @@ from typing import Any, AsyncIterable, AsyncIterator, Callable
 from unittest.mock import patch
 
 import httpx
+import pytest
 import respx
+from aioresponses import aioresponses
 from respx.types import SideEffectTypes
 
+from aidial_adapter_openai.app_config import ApplicationConfig
+from aidial_adapter_openai.constant import ChatCompletionDeploymentType
+from tests.conftest import create_test_client
 from tests.utils.dictionary import exclude_keys
 from tests.utils.stream import OpenAIStream, single_choice_chunk
 
@@ -769,3 +774,38 @@ async def test_incorrect_streaming_request(test_app: httpx.AsyncClient):
 
     assert response.status_code == 400
     assert response.json() == expected_response
+
+
+@pytest.mark.parametrize("stream", [False, True])
+async def test_error_from_gpt_multi_modal(stream: bool):
+    app_config = (
+        ApplicationConfig()
+        .add_deployment("app", ChatCompletionDeploymentType.GPT4O)
+        .map_to_tiktoken_model("app", "gpt-4")
+    )
+
+    with aioresponses() as aio_mock:
+        aio_mock.add(
+            method="POST",
+            url="http://test-upstream/?api-version=2023-03-15-preview",
+            body="Something went wrong",
+            status=500,
+            headers={"Content-Type": "text/plain"},
+        )
+
+        async with create_test_client(app_config=app_config) as http_client:
+
+            response = await http_client.post(
+                "/openai/deployments/app/chat/completions?api-version=2023-03-15-preview",
+                json={
+                    "messages": [{"role": "user", "content": "test"}],
+                    "stream": stream,
+                },
+                headers={
+                    "X-UPSTREAM-KEY": "dummy-upstream-api-key",
+                    "X-UPSTREAM-ENDPOINT": "http://test-upstream",
+                },
+            )
+
+            assert response.status_code == 500
+            assert response.content == b"Something went wrong"


### PR DESCRIPTION
Resolves #199 

Errors are typically returned as a plain text, not json, thus the following code is incorrect:

```python
            if response.status != 200:
                yield JSONResponse(
                    status_code=response.status, content=await response.json()
                )
```

It fails in `await response.json()` by throwing an error like this:

```
aiohttp.client_exceptions.ContentTypeError: 502, message='Attempt to decode JSON with unexpected mimetype: text/html; charset=utf-8'
``` 