### PR TITLE
fix: allow user-defined model field for `/embeddings` endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist
 .pytest_cache
 ~*
 integration_test_config.json
+.python-version

--- a/aidial_adapter_openai/endpoints/embeddings.py
+++ b/aidial_adapter_openai/endpoints/embeddings.py
@@ -20,7 +20,7 @@ async def embedding(deployment_id: str, request: Request):
     data = await parse_body(request)
 
     # See note for /chat/completions endpoint
-    data["model"] = deployment_id
+    data["model"] = data.get("model") or deployment_id
 
     creds = await get_credentials(request)
     api_version = get_api_version(request)


### PR DESCRIPTION
Similar to https://github.com/epam/ai-dial-adapter-openai/pull/197 , but for the embeddings endpoint.