### PR TITLE
chore: bumps xz-libs from 5.6.3-r0 to 5.6.3-r1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN apk update && apk upgrade --no-cache libcrypto3 libssl3
 RUN apk upgrade --no-cache libexpat
 # CVE-2024-6345
 RUN pip install setuptools==70.0.0
+# CVE-2025-31115
+RUN apk add --no-cache xz-libs==5.6.3-r1
 
 WORKDIR /app
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Fixes CVE-2025-31115 by upgrading version of **xz-libs** from 5.6.3-r0 to **5.6.3-r1**

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
