### PR TITLE
chore: bumps version of sqlite-libs from 3.48.0-r0 to 3.49.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,15 @@ RUN poetry install --no-interaction --no-ansi --no-cache --only main
 
 FROM python:3.11-alpine as server
 
-RUN apk update && apk upgrade --no-cache libcrypto3 libssl3
+RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 \
+    # fix CVE-2023-52425
+    && apk upgrade --no-cache libexpat \
+    # fix CVE-2025-31115
+    && apk add --no-cache xz-libs==5.6.3-r1 \
+    # fix CVE-2023-52425
+    && apk add --no-cache sqlite-libs==3.49.1 --force
 
-# CVE-2023-52425
-RUN apk upgrade --no-cache libexpat
-# CVE-2024-6345
 RUN pip install setuptools==70.0.0
-# CVE-2025-31115
-RUN apk add --no-cache xz-libs==5.6.3-r1
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 \
     && apk upgrade --no-cache libexpat \
     # fix CVE-2025-31115
     && apk add --no-cache xz-libs==5.6.3-r1 \
-    # fix CVE-2023-52425
+    # fix CVE-2025-29087
     && apk add --no-cache sqlite-libs==3.49.1 --force
 
 RUN pip install setuptools==70.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 \
     # fix CVE-2025-29087
     && apk add --no-cache sqlite-libs==3.49.1 --force
 
+# fix CVE-2024-6345
 RUN pip install setuptools==70.0.0
 
 WORKDIR /app


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes CVE-2025-29087

### Description of changes

<!-- Please explain the changes you made right below this line. -->
bumps version of sqlite-libs from 3.48.0-r0 to 3.49.1

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
