### PR TITLE
chore: revert: bumps version of sqlite-libs from 3.48.0-r0 to 3.49.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,16 +21,14 @@ RUN poetry install --no-interaction --no-ansi --no-cache --only main
 
 FROM python:3.11-alpine as server
 
-RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 \
-    # fix CVE-2023-52425
-    && apk upgrade --no-cache libexpat \
-    # fix CVE-2025-31115
-    && apk add --no-cache xz-libs==5.6.3-r1 \
-    # fix CVE-2025-29087
-    && apk add --no-cache sqlite-libs==3.49.1 --force
+RUN apk update && apk upgrade --no-cache libcrypto3 libssl3
 
-# fix CVE-2024-6345
+# CVE-2023-52425
+RUN apk upgrade --no-cache libexpat
+# CVE-2024-6345
 RUN pip install setuptools==70.0.0
+# CVE-2025-31115
+RUN apk add --no-cache xz-libs==5.6.3-r1
 
 WORKDIR /app
 


### PR DESCRIPTION
`python:3.11-alpine` image [depends on](https://hub.docker.com/layers/library/python/3.11-alpine3.21/images/sha256-81d42a73add8e508771ee8e923f9f8392ec1c3d1e482d7d594891d06e78fb51c) `sqlite-libs==3.48.0-r2` which already contains the required [vulnerability fix](https://gitlab.alpinelinux.org/alpine/aports/-/commit/f582ed9d5f50627745fb2fa93498103c53610638).

Therefore, we don't need to upgrade the package ourselves.