### PR TITLE
feat: support non-azure OpenAI endpoints for multi-modal GPTs

### DIFF
--- a/aidial_adapter_openai/gpt4_multi_modal/chat_completion.py
+++ b/aidial_adapter_openai/gpt4_multi_modal/chat_completion.py
@@ -25,7 +25,7 @@ from aidial_adapter_openai.gpt4_multi_modal.transformation import (
     ResourceProcessor,
 )
 from aidial_adapter_openai.utils.aiohttp import post
-from aidial_adapter_openai.utils.auth import OpenAICreds, get_auth_headers
+from aidial_adapter_openai.utils.auth import OpenAICreds
 from aidial_adapter_openai.utils.caching import (
     get_prompt_tokens_from_response,
     get_response_headers_for_caching,
@@ -35,6 +35,7 @@ from aidial_adapter_openai.utils.chat_completion_response import (
 )
 from aidial_adapter_openai.utils.log_config import logger
 from aidial_adapter_openai.utils.multi_modal_message import MultiModalMessage
+from aidial_adapter_openai.utils.parsers import chat_completions_parser
 from aidial_adapter_openai.utils.sse_stream import parse_openai_sse_stream
 from aidial_adapter_openai.utils.streaming import (
     ResponseWithHeaders,
@@ -254,7 +255,8 @@ async def _chat_completion(
         "messages": [m.raw_message for m in multi_modal_messages],
     }
 
-    headers = get_auth_headers(creds)
+    openai_endpoint = chat_completions_parser.parse(upstream_endpoint)
+    headers = openai_endpoint.get_auth_headers(creds)
 
     if is_stream:
         response = await predict_stream(api_url, headers, request)

--- a/aidial_adapter_openai/utils/auth.py
+++ b/aidial_adapter_openai/utils/auth.py
@@ -56,16 +56,6 @@ async def get_credentials(request: Request) -> OpenAICreds:
         return {"api_key": api_key}
 
 
-def get_auth_headers(creds: OpenAICreds) -> dict[str, str]:
-    if "api_key" in creds:
-        return {"api-key": creds["api_key"]}
-
-    if "azure_ad_token" in creds:
-        return {"Authorization": f"Bearer {creds['azure_ad_token']}"}
-
-    raise ValueError("Invalid credentials")
-
-
 class Auth(BaseModel):
     name: str
     value: str

--- a/aidial_adapter_openai/utils/parsers.py
+++ b/aidial_adapter_openai/utils/parsers.py
@@ -1,5 +1,4 @@
 import re
-from abc import ABC, abstractmethod
 from json import JSONDecodeError
 from typing import Any, Dict, TypedDict
 
@@ -8,6 +7,7 @@ from fastapi import Request
 from openai import AsyncAzureOpenAI, AsyncOpenAI, Timeout
 from pydantic import BaseModel
 
+from aidial_adapter_openai.utils.auth import OpenAICreds
 from aidial_adapter_openai.utils.http_client import get_http_client
 
 
@@ -16,12 +16,6 @@ class OpenAIParams(TypedDict, total=False):
     azure_ad_token: str
     api_version: str
     timeout: Timeout
-
-
-class Endpoint(ABC):
-    @abstractmethod
-    def get_client(self, params: OpenAIParams) -> AsyncOpenAI:
-        pass
 
 
 # Retries are handled on the DIAL Core side
@@ -44,6 +38,15 @@ class AzureOpenAIEndpoint(BaseModel):
             http_client=get_http_client(),
         )
 
+    def get_auth_headers(self, creds: OpenAICreds) -> dict[str, str]:
+        if key := creds.get("api_key"):
+            return {"api-key": key}
+
+        if token := creds.get("azure_ad_token"):
+            return {"Authorization": f"Bearer {token}"}
+
+        raise ValueError("Invalid credentials")
+
 
 class OpenAIEndpoint(BaseModel):
     base_url: str
@@ -56,6 +59,11 @@ class OpenAIEndpoint(BaseModel):
             max_retries=_MAX_RETRIES,
             http_client=get_http_client(),
         )
+
+    def get_auth_headers(self, creds: OpenAICreds) -> dict[str, str]:
+        if key := (creds.get("api_key") or creds.get("azure_ad_token")):
+            return {"Authorization": f"Bearer {key}"}
+        raise ValueError("Invalid credentials")
 
 
 def _parse_endpoint(

--- a/tests/unit_tests/test_caching.py
+++ b/tests/unit_tests/test_caching.py
@@ -136,7 +136,7 @@ async def test_auto_caching(
 
     query_part = "api-version=2023-03-15-preview"
     adapter_url = f"chat/completions?{query_part}"
-    upstream_endpoint = "http://test-upstream"
+    upstream_endpoint = "http://test-upstream/openai/deployments/upstream-deployment/chat/completions"
     upstream_url = f"{upstream_endpoint}?{query_part}"
 
     mock_response(

--- a/tests/unit_tests/test_errors.py
+++ b/tests/unit_tests/test_errors.py
@@ -784,10 +784,12 @@ async def test_error_from_gpt_multi_modal(stream: bool):
         .map_to_tiktoken_model("app", "gpt-4")
     )
 
+    upstream_url = "http://test-upstream/openai/deployments/upstream-deployment/chat/completions"
+
     with aioresponses() as aio_mock:
         aio_mock.add(
             method="POST",
-            url="http://test-upstream/?api-version=2023-03-15-preview",
+            url=f"{upstream_url}?api-version=2023-03-15-preview",
             body="Something went wrong",
             status=500,
             headers={"Content-Type": "text/plain"},
@@ -803,7 +805,7 @@ async def test_error_from_gpt_multi_modal(stream: bool):
                 },
                 headers={
                     "X-UPSTREAM-KEY": "dummy-upstream-api-key",
-                    "X-UPSTREAM-ENDPOINT": "http://test-upstream",
+                    "X-UPSTREAM-ENDPOINT": upstream_url,
                 },
             )
 
@@ -817,7 +819,7 @@ async def test_missing_tiktoken_model(test_app: httpx.AsyncClient):
         json={"whatever": "whatever"},
         headers={
             "X-UPSTREAM-KEY": "dummy-upstream-api-key",
-            "X-UPSTREAM-ENDPOINT": "http://test-upstream",
+            "X-UPSTREAM-ENDPOINT": "http://test-upstream/openai/deployments/upstream-deployment/chat/completions",
         },
     )
 


### PR DESCRIPTION
The following curl request was failing:

```sh
function openai_native_via_adapter() {
  CHAT_MODEL=gpt-4.1-2025-04-14

  URL=http://0.0.0.0:5006/openai/deployments/${CHAT_MODEL}/chat/completions?api-version=2025-01-01-preview
  UPSTREAM_URL=https://api.openai.com/v1/chat/completions
  UPSTREAM_KEY=key...

  curl -X POST $URL \
    -H "X-UPSTREAM-ENDPOINT:${UPSTREAM_URL}" \
    -H "X-UPSTREAM-KEY:${UPSTREAM_KEY}" \
    -d '{"model": "gpt-4.1-2025-04-14", "messages":[{"role":"user", "content": "2+3=?"}], "stream": true}'
}

openai_native_via_adapter
```

with the following 401 error:

```json
{
    "error": {
        "message": "You didn't provide an API key. You need to provide your API key in an Authorization header using Bearer auth (i.e. Authorization: Bearer YOUR_KEY), or as the password field (with blank username) if you're accessing the API from your browser and are prompted for a username and password. You can obtain an API key from https://platform.openai.com/account/api-keys.",
        "type": "invalid_request_error",
        "param": null,
        "code": null
    }
}
```

Where `gpt-4.1-2025-04-14` is configured in the following way in the adapter:

```
GPT4O_DEPLOYMENTS=gpt-4.1-2025-04-14
MODEL_ALIASES={"gpt-4.1-2025-04-14":"gpt-4o"}
```

It happens because the api-key was passed via `api-key` header which is fine by Azure OpenAI deployments, but not for the native OpenAI deployments. They requried the key passed in the `Authorization` header.

The solution is to identify wheither the endpoint is non-Azure OpenAI or Azure OpenAI and construct headers accordingly.

`openai` library handles these differences gracefully, however, we don't use it in the adapter for the multi-modal models.
In the long run, we should switch to the `openai` library rather than making API calls via HTTP ourselves.