### PR TITLE
fix: support calling Dall-E-3 from OpenAI Platform

### DIFF
--- a/aidial_adapter_openai/dalle3.py
+++ b/aidial_adapter_openai/dalle3.py
@@ -103,6 +103,7 @@ async def move_attachments_data_to_storage(
 
 async def chat_completion(
     data: Any,
+    deployment: str,
     upstream_endpoint: str,
     creds: OpenAICreds,
     is_stream: bool,
@@ -121,6 +122,7 @@ async def chat_completion(
     config = get_configuration(Dalle3Config, data) or Dalle3Config()
 
     model_response = await client.images.generate(
+        model=deployment,
         prompt=user_prompt,
         response_format="b64_json",
         extra_body=config.dict(exclude_none=True),

--- a/aidial_adapter_openai/endpoints/chat_completion.py
+++ b/aidial_adapter_openai/endpoints/chat_completion.py
@@ -92,6 +92,7 @@ async def call_chat_completion(
         case ChatCompletionDeploymentType.DALLE3:
             return await dalle3_chat_completion(
                 data,
+                deployment_id,
                 upstream_endpoint,
                 creds,
                 is_stream,

--- a/tests/unit_tests/test_dalle3.py
+++ b/tests/unit_tests/test_dalle3.py
@@ -18,11 +18,11 @@ _DALLE_API_VERSION = "dalle-3-api-version"
 async def dalle3_client():
     app_config = ApplicationConfig(
         DALLE3_AZURE_API_VERSION=_DALLE_API_VERSION
-    ).add_deployment("app", ChatCompletionDeploymentType.DALLE3)
+    ).add_deployment("test-dall-e-3", ChatCompletionDeploymentType.DALLE3)
 
     async with create_test_client(
         app_config=app_config,
-        base_url="http://test-app.com/openai/deployments/app",
+        base_url="http://test-app.com/openai/deployments/test-dall-e-3",
     ) as client:
         yield client
 
@@ -60,6 +60,7 @@ async def test_dalle3_configuration_success(
 ):
     def _mock_dalle3_response(request: httpx.Request):
         assert json.loads(request.content) == {
+            "model": "test-dall-e-3",
             "prompt": "test",
             "response_format": "b64_json",
             **remove_nones(conf or {}),


### PR DESCRIPTION
Before the fix the requests to *OpenAI Platform* were actually directed to **dall-e-2** instead of **dall-e-3**, because a missing `model` parameter is defaulted to **dall-e-2**.

It didn't happen for Azure OpenAI deployments, because there deployment is extracted from the endpoint itself.