### PR TITLE
chore: remove xz-libs upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,6 @@ RUN apk update && apk upgrade --no-cache libcrypto3 libssl3
 RUN apk upgrade --no-cache libexpat
 # CVE-2025-47273
 RUN pip install setuptools==78.1.1
-# CVE-2025-31115
-RUN apk add --no-cache xz-libs==5.6.3-r1
 
 WORKDIR /app
 


### PR DESCRIPTION
Reverting the fix: https://github.com/epam/ai-dial-adapter-openai/pull/211 for the [vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2025-31115):

```
# CVE-2025-31115
RUN apk add --no-cache xz-libs==5.6.3-r1
```

Because `python:3.11-alpine` included `apk / alpine/xz-libs / 5.8.1-r0` that has the required vulnerability fix:
https://hub.docker.com/layers/library/python/3.11-alpine/images/sha256-3de0c60ea782b0a1528959d00c75989adbcc7042cce562dfc5d2da58c130bb11

Otherwise, the upgrade breaks the Docker build:

```
 > [server  5/10] RUN apk add --no-cache xz-libs==5.6.3-r1:
0.082 fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz
0.190 fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/community/x86_64/APKINDEX.tar.gz
0.541 ERROR: unable to select packages:
0.542   xz-libs-5.8.1-r0:
0.542     breaks: world[xz-libs=5.6.3-r1]
0.542     satisfies: .python-rundeps-20250604.171225[so:liblzma.so.5]
```
