### PR TITLE
fix: enable proxy configuration via env vars for gpt-4o deployments

### DIFF
--- a/aidial_adapter_openai/utils/aiohttp.py
+++ b/aidial_adapter_openai/utils/aiohttp.py
@@ -78,7 +78,9 @@ def _get_tracing_timings(trace_request_ctx: dict) -> str:
 @contextlib.asynccontextmanager
 async def post(url: str, headers: Dict[str, str], request: Any):
     ctx = {}
-    async with aiohttp.ClientSession(trace_configs=[_trace_config]) as session:
+    async with aiohttp.ClientSession(
+        trust_env=True, trace_configs=[_trace_config]
+    ) as session:
         async with session.post(
             url, json=request, headers=headers, trace_request_ctx=ctx
         ) as response:


### PR DESCRIPTION
1. Deployments declared in `GPT4O_DEPLOYMENTS` are called via `aiohttp` library. But default, it doesn't trust_env: https://docs.aiohttp.org/en/stable/client_reference.html
2. Deployments not declared in `GPT4O_DEPLOYMENTS` are called via `httpx` library _(from `openai` lib)_. By default, it does trust_env: https://www.python-httpx.org/environment_variables/

Trusting env means that the client picks up proxy configuration from the env vars _(e.g. `HTTP_PROXY` env var)._

The given fix syncs this feature between the two clients.

In the long run we need to migrate from `aiohttp` altogether: #203 