### PR TITLE
fix: preserve non-empty id field when `ELIMINATE_EMPTY_CHOICES=True`

### DIFF
--- a/aidial_adapter_openai/utils/streaming.py
+++ b/aidial_adapter_openai/utils/streaming.py
@@ -123,7 +123,7 @@ async def generate_stream(
             response_snapshot.merge(chunk)
 
             if buffer_chunk is not None:
-                chunk = merge_chat_completion_chunks(chunk, buffer_chunk)
+                chunk = merge_chat_completion_chunks(buffer_chunk, chunk)
                 buffer_chunk = None
 
             choices = chunk.get("choices") or []

--- a/tests/unit_tests/test_streaming.py
+++ b/tests/unit_tests/test_streaming.py
@@ -132,7 +132,76 @@ async def test_include_usage(test_app: httpx.AsyncClient):
 
 
 @respx.mock
-async def test_include_usage_stream_issues(
+async def test_empty_usage_with_content_filter_results(
+    eliminate_empty_choices, test_app: httpx.AsyncClient
+):
+    # Modeled after the example from the Azure doc:
+    # https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/content-streaming#sample-response-stream-passes-filters
+    upstream_response = OpenAIStream(
+        chunk(
+            id="",
+            object_="",
+            created=0,
+            model="",
+            choices=[],
+            prompt_filter_results="prompt_filter_results_placeholder",
+        ),
+        single_choice_chunk(delta={"role": "assistant"}),
+        single_choice_chunk(delta={"content": "Test content"}),
+        single_choice_chunk(
+            delta={},
+            finish_reason="stop",
+            usage={
+                "completion_tokens": 111,
+                "prompt_tokens": 222,
+                "total_tokens": 333,
+            },
+        ),
+    )
+
+    respx.post(
+        "http://localhost:5001/openai/deployments/gpt-4/chat/completions?api-version=2023-06-15"
+    ).respond(
+        status_code=200,
+        content=upstream_response.to_content(),
+        content_type="text/event-stream",
+    )
+
+    response = await test_app.post(
+        "/openai/deployments/gpt-4/chat/completions?api-version=2023-06-15",
+        json={
+            "messages": [{"role": "user", "content": "Test content"}],
+            "stream": True,
+        },
+        headers={
+            "X-UPSTREAM-KEY": "TEST_API_KEY",
+            "X-UPSTREAM-ENDPOINT": "http://localhost:5001/openai/deployments/gpt-4/chat/completions",
+        },
+    )
+
+    expected_response = OpenAIStream(
+        single_choice_chunk(
+            delta={"role": "assistant"},
+            prompt_filter_results="prompt_filter_results_placeholder",
+        ),
+        single_choice_chunk(delta={"content": "Test content"}),
+        single_choice_chunk(
+            delta={},
+            finish_reason="stop",
+            usage={
+                "completion_tokens": 111,
+                "prompt_tokens": 222,
+                "total_tokens": 333,
+            },
+        ),
+    )
+
+    assert response.status_code == 200
+    expected_response.assert_response_content(response, assert_equal)
+
+
+@respx.mock
+async def test_empty_choice_with_usage(
     eliminate_empty_choices, test_app: httpx.AsyncClient
 ):
     # Emulating the steam returned by OpenAI when stream_options.include_usage=True

--- a/tests/utils/stream.py
+++ b/tests/utils/stream.py
@@ -55,6 +55,7 @@ class OpenAIStream:
 def chunk(
     *,
     id: str = "chatcmpl-test",
+    object_: str = "chat.completion.chunk",
     created: int = 1695940483,
     model: str = "gpt-4",
     choices: List[dict],
@@ -63,7 +64,7 @@ def chunk(
 ) -> dict:
     return {
         "id": id,
-        "object": "chat.completion.chunk",
+        "object": object_,
         "created": created,
         "model": model,
         "choices": choices,
@@ -75,6 +76,7 @@ def chunk(
 def single_choice_chunk(
     *,
     id: str = "chatcmpl-test",
+    object_: str = "chat.completion.chunk",
     created: int = 1695940483,
     model: str = "gpt-4",
     finish_reason: str | None = None,
@@ -87,6 +89,7 @@ def single_choice_chunk(
         id=id,
         created=created,
         model=model,
+        object_=object_,
         choices=[
             {
                 "index": 0,


### PR DESCRIPTION
Given that `ELIMINATE_EMPTY_CHOICES=True`:

**Before**: the empty choice chunk was overriding object/created/model/id fields in the follow-up non-empty choice chunk:

```
data: {"id":"","object":"","created":0,"model":"","prompt_annotations":"foobar","choices":[],"usage":null} 
data: {"id":"chatcmpl-7rCNsVeZy0PGnX3H6jK8STps5nZUY","object":"chat.completion.chunk","created":1692913344,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant"}}],"usage":null} 
===>
data: {"id":"","object":"","created":0,"model":"","choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant"}}],"usage":null,"prompt_annotations":"foobar"} 
```

**After**: the empty choice chunk is merged with the follow-up chunk without corrupting its object/created/model/id fields:

```
data: {"id":"","object":"","created":0,"model":"","prompt_annotations":"foobar","choices":[],"usage":null} 
data: {"id":"chatcmpl-7rCNsVeZy0PGnX3H6jK8STps5nZUY","object":"chat.completion.chunk","created":1692913344,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant"}}],"usage":null} 
===>
data: {"id":"chatcmpl-7rCNsVeZy0PGnX3H6jK8STps5nZUY","object":"chat.completion.chunk","created":1692913344,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant"}}],"usage":null,"prompt_annotations":"foobar"}
```

See also the relevant [doc](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/content-streaming#sample-response-stream-passes-filters) from Azure.