### PR TITLE
fix: bump sqlite-libs from 3.49.2-r0 to 3.49.2-r1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,12 @@ FROM python:3.11-alpine AS server
 
 RUN apk update && apk upgrade --no-cache libcrypto3 libssl3
 
-# CVE-2023-52425
+# fix CVE-2023-52425
 RUN apk upgrade --no-cache libexpat
-# CVE-2025-47273
+# fix CVE-2025-47273
 RUN pip install setuptools==78.1.1
+# fix CVE-2025-6965
+RUN apk upgrade --no-cache sqlite-libs
 
 WORKDIR /app
 


### PR DESCRIPTION
Security fix for https://github.com/epam/ai-dial-adapter-openai/security/code-scanning/6