### PR TITLE
fix: simplified `DeploymentAPIType`

### DIFF
--- a/aidial_adapter_openai/configuration/app_config.py
+++ b/aidial_adapter_openai/configuration/app_config.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import os
 from typing import Dict, List, assert_never
 
-from pydantic import BaseModel
-
 from aidial_adapter_openai.configuration.deployment_type import (
     ChatCompletionDeploymentType as D,
 )
@@ -26,26 +24,15 @@ from aidial_adapter_openai.utils.parsers import (
     image_gen_parser,
     responses_parser,
 )
+from aidial_adapter_openai.utils.pydantic import ExtraForbidModel
 
 
-# TODO: investigate: the unit test `test_deployment_api_type`
-# fails when `DeploymentAPIType` inherits from `BaseModel`,
-# even if their signatures do not overlap.
-class DeploymentAPIType:
+class DeploymentAPIType(ExtraForbidModel):
     deployment_type: D
     endpoint: AzureOpenAIEndpoint | OpenAIEndpoint
 
-    def __init__(
-        self,
-        *,
-        deployment_type: D,
-        endpoint: AzureOpenAIEndpoint | OpenAIEndpoint,
-    ) -> None:
-        self.deployment_type = deployment_type
-        self.endpoint = endpoint
 
-
-class ApplicationConfig(BaseModel):
+class ApplicationConfig(ExtraForbidModel):
     TIKTOKEN_MODEL_MAPPING: Dict[str, str] = {}
 
     DALLE3_DEPLOYMENTS: List[str] = []

--- a/aidial_adapter_openai/utils/parsers.py
+++ b/aidial_adapter_openai/utils/parsers.py
@@ -5,10 +5,10 @@ from typing import Any, Dict, TypedDict
 from aidial_sdk.exceptions import InvalidRequestError
 from fastapi import Request
 from openai import AsyncAzureOpenAI, AsyncOpenAI, Timeout
-from pydantic import BaseModel
 
 from aidial_adapter_openai.utils.auth import OpenAICreds
 from aidial_adapter_openai.utils.http_client import get_http_client
+from aidial_adapter_openai.utils.pydantic import ExtraForbidModel
 
 
 class OpenAIParams(TypedDict, total=False):
@@ -23,7 +23,7 @@ class OpenAIParams(TypedDict, total=False):
 _MAX_RETRIES = 0
 
 
-class AzureOpenAIEndpoint(BaseModel):
+class AzureOpenAIEndpoint(ExtraForbidModel):
     azure_base_url: str | None = None
     azure_endpoint: str | None = None
     azure_deployment: str | None = None
@@ -54,7 +54,7 @@ class AzureOpenAIEndpoint(BaseModel):
         raise ValueError("Invalid credentials")
 
 
-class OpenAIEndpoint(BaseModel):
+class OpenAIEndpoint(ExtraForbidModel):
     base_url: str
 
     def get_client(self, params: OpenAIParams) -> AsyncOpenAI:
@@ -94,7 +94,7 @@ def _parse_endpoint(
     return None
 
 
-class EndpointParser(BaseModel):
+class EndpointParser(ExtraForbidModel):
     name: str
 
     def try_parse(
@@ -108,7 +108,7 @@ class EndpointParser(BaseModel):
         raise InvalidRequestError("Invalid upstream endpoint format")
 
 
-class CompletionsParser(BaseModel):
+class CompletionsParser(ExtraForbidModel):
     def try_parse(
         self, endpoint: str
     ) -> AzureOpenAIEndpoint | OpenAIEndpoint | None:

--- a/aidial_adapter_openai/utils/pydantic.py
+++ b/aidial_adapter_openai/utils/pydantic.py
@@ -4,3 +4,8 @@ from pydantic import BaseModel
 class ExtraAllowedModel(BaseModel):
     class Config:
         extra = "allow"
+
+
+class ExtraForbidModel(BaseModel):
+    class Config:
+        extra = "forbid"


### PR DESCRIPTION
Used `BaseModel` with extra fields forbidden, in order to fix the bug described and fixed _(but less elegantly)_ in the issue https://github.com/epam/ai-dial-adapter-openai/pull/261