### PR TITLE
fix: fix Mistral deployments

### DIFF
--- a/aidial_adapter_openai/configuration/app_config.py
+++ b/aidial_adapter_openai/configuration/app_config.py
@@ -24,6 +24,7 @@ from aidial_adapter_openai.utils.parsers import (
     chat_completions_parser,
     completions_parser,
     image_gen_parser,
+    no_endpoint_parser,
     responses_parser,
 )
 
@@ -83,7 +84,7 @@ class ApplicationConfig(BaseModel):
         if deployment_id in self.MISTRAL_DEPLOYMENTS:
             return DeploymentAPIType(
                 deployment_type=D.MISTRAL,
-                endpoint=chat_completions_parser.parse(upstream_endpoint),
+                endpoint=no_endpoint_parser.parse(upstream_endpoint),
             )
 
         if deployment_id in self.DATABRICKS_DEPLOYMENTS:

--- a/aidial_adapter_openai/utils/parsers.py
+++ b/aidial_adapter_openai/utils/parsers.py
@@ -73,29 +73,33 @@ class OpenAIEndpoint(BaseModel):
 
 
 def _parse_endpoint(
-    name, endpoint
+    name: str | None, endpoint: str
 ) -> AzureOpenAIEndpoint | OpenAIEndpoint | None:
-    if match := re.search(f"(.+?)/openai/deployments/(.+?)/{name}", endpoint):
+    if name is not None:
+        suffix = f"/{name}"
+        if not endpoint.endswith(suffix):
+            return None
+        endpoint = endpoint.removesuffix(suffix)
+
+    if match := re.fullmatch("(.+?)/openai/deployments/(.+)", endpoint):
         return AzureOpenAIEndpoint(
             azure_endpoint=match[1],
             azure_deployment=match[2],
         )
-    if match := re.search(f"(.+?)/openai/{name}", endpoint):
+    if match := re.fullmatch("(.+?)/openai", endpoint):
         return AzureOpenAIEndpoint(
             azure_endpoint=match[1],
         )
-    if match := re.search(f"(.+?)/openai/v1/{name}", endpoint):
+    if match := re.fullmatch("(.+?)/openai/v1", endpoint):
         return AzureOpenAIEndpoint(
-            azure_base_url=f"{match[1]}/openai/v1",
+            azure_base_url=endpoint,
             next_gen_api=True,
         )
-    if match := re.search(f"(.+?)/{name}", endpoint):
-        return OpenAIEndpoint(base_url=match[1])
-    return None
+    return OpenAIEndpoint(base_url=endpoint)
 
 
 class EndpointParser(BaseModel):
-    name: str
+    name: str | None
 
     def try_parse(
         self, endpoint: str
@@ -122,6 +126,7 @@ chat_completions_parser = EndpointParser(name="chat/completions")
 image_gen_parser = EndpointParser(name="images/generations")
 embeddings_parser = EndpointParser(name="embeddings")
 responses_parser = EndpointParser(name="responses")
+no_endpoint_parser = EndpointParser(name=None)
 completions_parser = CompletionsParser()
 
 

--- a/tests/unit_tests/test_parsers.py
+++ b/tests/unit_tests/test_parsers.py
@@ -6,6 +6,7 @@ from aidial_adapter_openai.utils.parsers import (
     OpenAIEndpoint,
     chat_completions_parser,
     completions_parser,
+    no_endpoint_parser,
     responses_parser,
 )
 
@@ -26,6 +27,39 @@ RESPONSE_CASES = [
         ),
     ),
 ]
+
+NO_ENDPOINT_CASES = [
+    (
+        "https://test.com/openai/deployments/test-deployment",
+        AzureOpenAIEndpoint(
+            azure_endpoint="https://test.com",
+            azure_deployment="test-deployment",
+        ),
+    ),
+    (
+        "https://test.com/my/models/openai/deployments/test-deployment",
+        AzureOpenAIEndpoint(
+            azure_endpoint="https://test.com/my/models",
+            azure_deployment="test-deployment",
+        ),
+    ),
+    (
+        "https://test.com/openai/deployments/test-deployment-chat",
+        AzureOpenAIEndpoint(
+            azure_endpoint="https://test.com",
+            azure_deployment="test-deployment-chat",
+        ),
+    ),
+    (
+        "https://test.com/openai/deployments",
+        OpenAIEndpoint(base_url="https://test.com/openai/deployments"),
+    ),
+    (
+        "https://test.com/my/endpoint",
+        OpenAIEndpoint(base_url="https://test.com/my/endpoint"),
+    ),
+]
+
 
 NORMAL_CHAT_CASES = [
     (
@@ -134,4 +168,10 @@ def test_completions_parser_invalid(endpoint, parsed):
 @pytest.mark.parametrize("endpoint, parsed", RESPONSE_CASES)
 def test_responses_parser(endpoint, parsed):
     result = responses_parser.try_parse(endpoint)
+    assert result == parsed
+
+
+@pytest.mark.parametrize("endpoint, parsed", NO_ENDPOINT_CASES)
+def test_no_endpoint_parser(endpoint, parsed):
+    result = no_endpoint_parser.try_parse(endpoint)
     assert result == parsed


### PR DESCRIPTION
Due to a bug, the following Mistral chat completion deployment was not possible to use:

```text
DIAL Core Config:
{
  "models": {
    "my-mistral-deployment": {
      "type": "chat",
      "overrideName": "mistral-model-name",
      "upstreams": [
        {
          "endpoint": "${HOSTNAME}/models",
          "key": "key"
        }
      ]
    }
  }
}

OpenAI env vars:
MISTRAL_DEPLOYMENTS=my-mistral-deployment
```

Historically, endpoints to `MISTRAL_DEPLOYMENTS` were expected **not to end** with the `chat/completions` suffix.

The bug introduced by https://github.com/epam/ai-dial-adapter-openai/pull/244 which was included in release [0.29.0](https://github.com/epam/ai-dial-adapter-openai/releases/tag/0.29.0) changed this behaviour and introduced an expectation that the Mistal endpoints must end with the `chat/completions` suffix.

Therefore, the described Mistral model configuration leads to the error:

> Caught exception: aidial_sdk.exceptions.InvalidRequestError. Converted to the adapter exception: InvalidRequestError(message='Invalid upstream endpoint format', status_code=400, type='invalid_request_error', param=None, code='400', display_message=None)

This PR restores the original behaviour.