### PR TITLE
fix: fix logging format of HTTP request

### DIFF
--- a/aidial_adapter_openai/utils/httpx.py
+++ b/aidial_adapter_openai/utils/httpx.py
@@ -87,9 +87,7 @@ async def _log_timings_hook(response: httpx.Response) -> None:
             "completions"
         )
         level = logging.INFO if is_model_call else logging.DEBUG
-        msg = (
-            f"Upstream: {url!r}. Status: {response.status_code}. Timing: {_get_tracing_timings(ctx)}.",
-        )
+        msg = f"Upstream: {url!r}. Status: {response.status_code}. Timing: {_get_tracing_timings(ctx)}."
         logger.log(level, msg)
 
     if response.is_closed:


### PR DESCRIPTION
Fixed regression in the format of the log message for a HTTP request. 
The regression was introduced in https://github.com/epam/ai-dial-adapter-openai/pull/251

Before:

> [2025-08-05 12:34:36 - aidial_adapter_openai:93 - DEBUG] ("Upstream: '.../openai/deployments/deployment-name/chat/completions?api-version=2024-10-21'. Status: 200. Timing: 1094 (dns=na, connect=298, header=642, body=1).",)

After: 

> [2025-08-05 12:39:01 - aidial_adapter_openai:93 - DEBUG] Upstream: '.../openai/deployments/deployment-name/chat/completions?api-version=2024-10-21'. Status: 200. Timing: 1094 (dns=na, connect=298, header=642, body=1).