### PR TITLE
feat: support next generation API endpoints (aka v1 API)

### DIFF
--- a/aidial_adapter_openai/endpoints/chat_completion.py
+++ b/aidial_adapter_openai/endpoints/chat_completion.py
@@ -71,6 +71,7 @@ async def call_chat_completion(
     deployment = app_config.get_chat_completion_deployment_type(
         deployment_id, upstream_endpoint
     )
+    logger.debug(f"deployment api type: {deployment.json()}")
     deployment_type, endpoint = deployment.deployment_type, deployment.endpoint
 
     tiktoken_model = (

--- a/aidial_adapter_openai/utils/parsers.py
+++ b/aidial_adapter_openai/utils/parsers.py
@@ -26,7 +26,6 @@ class AzureOpenAIEndpoint(ExtraForbidModel):
     azure_base_url: str | None = None
     azure_endpoint: str | None = None
     azure_deployment: str | None = None
-    next_gen_api: bool = False
 
     def get_client(self, params: OpenAIParams) -> AsyncAzureOpenAI:
         return AsyncAzureOpenAI(
@@ -35,9 +34,7 @@ class AzureOpenAIEndpoint(ExtraForbidModel):
             azure_deployment=self.azure_deployment,
             api_key=params.get("api_key"),
             azure_ad_token=params.get("azure_ad_token"),
-            api_version=(
-                "preview" if self.next_gen_api else params.get("api_version")
-            ),
+            api_version=params.get("api_version"),
             timeout=params.get("timeout"),
             max_retries=_MAX_RETRIES,
             http_client=get_http_client(),
@@ -68,17 +65,19 @@ def _parse_endpoint(
             return None
         endpoint = endpoint.removesuffix(suffix)
 
+    # Last generation API
     if match := re.fullmatch("(.+?)/openai/deployments/(.+)", endpoint):
         return AzureOpenAIEndpoint(
             azure_endpoint=match[1], azure_deployment=match[2]
         )
 
+    # Solely for Response API (last generation)
+    # https://github.com/MicrosoftDocs/azure-ai-docs/commit/a8f37469a3ce23fcee32512d37068a9627b470d3#diff-a379a6b7b341ba9e352ab413b170b27e33790719a8631fff5d3eeac4d0a33b26R147
     if match := re.fullmatch("(.+?)/openai", endpoint):
         return AzureOpenAIEndpoint(azure_endpoint=match[1])
 
-    if match := re.fullmatch("(.+?)/openai/v1", endpoint):
-        return AzureOpenAIEndpoint(azure_base_url=endpoint, next_gen_api=True)
-
+    # Falling back to the Next generation API (aka v1 API):
+    # https://learn.microsoft.com/en-us/azure/ai-foundry/openai/api-version-lifecycle?tabs=key#v1-api-support
     return OpenAIEndpoint(base_url=endpoint)
 
 

--- a/tests/integration_tests/integration_test_config_example.json
+++ b/tests/integration_tests/integration_test_config_example.json
@@ -22,7 +22,7 @@
             "type": "chat",
             "upstreams": [
                 {
-                    "endpoint": "https://azure-openai-service-name.openai.azure.com/openai/deployments/gpt-5-2025-08-07/chat/completions",
+                    "endpoint": "https://azure-openai-service-name.openai.azure.com/openai/v1/chat/completions",
                     "key": "optional-api-key"
                 }
             ],

--- a/tests/integration_tests/integration_test_config_example.json
+++ b/tests/integration_tests/integration_test_config_example.json
@@ -19,6 +19,7 @@
             ]
         },
         "gpt-5-2025-08-07": {
+            "overrideName": "gpt-5-2025-08-07",
             "type": "chat",
             "upstreams": [
                 {

--- a/tests/unit_tests/test_app_config.py
+++ b/tests/unit_tests/test_app_config.py
@@ -67,7 +67,7 @@ def test_app_config_chat_responses_azure_prev_gen(origin: str, deployment: str):
 
     assert ty.deployment_type == D.RESPONSES_API
     assert ty.endpoint == AzureOpenAIEndpoint(
-        azure_endpoint=f"{origin}/whatever1/whatever2", next_gen_api=False
+        azure_endpoint=f"{origin}/whatever1/whatever2"
     )
 
 
@@ -77,9 +77,8 @@ def test_app_config_chat_responses_azure_next_gen(origin: str, deployment: str):
     )
 
     assert ty.deployment_type == D.RESPONSES_API
-    assert ty.endpoint == AzureOpenAIEndpoint(
-        azure_base_url=f"{origin}/whatever1/whatever2/openai/v1",
-        next_gen_api=True,
+    assert ty.endpoint == OpenAIEndpoint(
+        base_url=f"{origin}/whatever1/whatever2/openai/v1"
     )
 
 
@@ -93,6 +92,24 @@ def test_app_config_chat_responses_openai_platform(
     assert ty.deployment_type == D.RESPONSES_API
     assert ty.endpoint == OpenAIEndpoint(
         base_url=f"{origin}/whatever1/whatever2"
+    )
+
+
+def test_app_config_chat_completions_azure_next_gen(
+    origin: str, deployment: str
+):
+    ty = (
+        ApplicationConfig()
+        .add_deployment(deployment, D.GPT4O)
+        .get_chat_completion_deployment_type(
+            deployment,
+            f"{origin}/whatever1/whatever2/openai/v1/chat/completions",
+        )
+    )
+
+    assert ty.deployment_type == D.GPT4O
+    assert ty.endpoint == OpenAIEndpoint(
+        base_url=f"{origin}/whatever1/whatever2/openai/v1"
     )
 
 

--- a/tests/unit_tests/test_parsers.py
+++ b/tests/unit_tests/test_parsers.py
@@ -13,17 +13,12 @@ from aidial_adapter_openai.utils.parsers import (
 RESPONSE_CASES = [
     (
         "https://test.com/openai/v1/responses",
-        AzureOpenAIEndpoint(
-            azure_base_url="https://test.com/openai/v1",
-            next_gen_api=True,
-        ),
+        OpenAIEndpoint(base_url="https://test.com/openai/v1"),
     ),
     (
         "https://test.com/openai/responses",
         AzureOpenAIEndpoint(
-            azure_endpoint="https://test.com",
-            azure_deployment=None,
-            next_gen_api=False,
+            azure_endpoint="https://test.com", azure_deployment=None
         ),
     ),
 ]

--- a/tests/unit_tests/test_responses.py
+++ b/tests/unit_tests/test_responses.py
@@ -23,9 +23,9 @@ async def test_response_model_name(test_app: httpx.AsyncClient):
             status_code=200, content=json.dumps(dummy_response.dict())
         )
 
-    respx.post(
-        "http://localhost:5001/openai/v1/responses?api-version=preview"
-    ).mock(side_effect=check_request)
+    respx.post("http://localhost:5001/openai/v1/responses").mock(
+        side_effect=check_request
+    )
 
     response = await test_app.post(
         "/openai/deployments/adapter-deployment-name/chat/completions?api-version=2023-03-15-preview",


### PR DESCRIPTION
The v1 API chat completion endpoints are supported following the [doc](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/api-version-lifecycle?tabs=key#v1-api-support).

An example of DIAL Core config:

```json
{
    "models": {
        "my-dial-depoyment-id": {
            "type": "chat",
            "overrideName": "gpt-5-2025-08-07",
            "upstreams": [
                {
                    "endpoint": "https://azure-openai-service-name.openai.azure.com/openai/v1/chat/completions",
                    "key": "optional-api-key"
                }
            ],
            "inputAttachmentTypes": [
                "image/*"
            ]
        }
    }
}
```

> [!IMPORTANT]
> `overrideName` field must be provided, since the upstream deployment id isn't included in the upstream endpoint.