### PR TITLE
fix: Sora: report number of seconds in `usage.completion_tokens`

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,10 @@ Find the details in the [Azure API specification](https://github.com/Azure/azure
 > [!NOTE]
 > `n_variants>1` results in multiple video attachments to a **single chat completion choice**.
 
+> [!IMPORTANT]
+> Prompt tokens in the usage are set to zero.
+> Completion tokens are set to the overall number of seconds in the generated video(s).
+
 #### OpenAI Completions API
 
 The adapter also supports **legacy** [Completions API](https://platform.openai.com/docs/api-reference/completions/create) both for Azure-style upstream endpoints and OpenAI Platform-style endpoints:

--- a/aidial_adapter_openai/video_generation/azure/adapter.py
+++ b/aidial_adapter_openai/video_generation/azure/adapter.py
@@ -26,6 +26,7 @@ from aidial_adapter_openai.video_generation.azure.prompt import VideoGenPrompt
 from aidial_adapter_openai.video_generation.azure.types import (
     CreateVideoGenerationRequest,
     JobStatus,
+    VideoGeneration,
 )
 
 
@@ -93,7 +94,7 @@ async def _poll_job(
     client: AzureVideoAPIClient,
     job_id: str,
     polling_interval: float,
-) -> List[str]:
+) -> List[VideoGeneration]:
     while True:
         await asyncio.sleep(polling_interval)
 
@@ -109,7 +110,7 @@ async def _poll_job(
                     raise InternalServerError(
                         "Video generation succeeded but no generations found"
                     )
-                return [g.id for g in generations]
+                return generations
 
             case JobStatus.FAILED:
                 video_job.failed()
@@ -136,17 +137,18 @@ async def _download_videos(
     response: DIALResponse,
     choice: Choice,
     client: AzureVideoAPIClient,
-    video_ids: List[str],
+    video_generations: List[VideoGeneration],
     storage: FileStorage | None,
 ):
-    n = len(video_ids)
+    n = len(video_generations)
+    seconds = sum(v.n_seconds for v in video_generations)
     response.set_usage(
         prompt_tokens=0,
-        completion_tokens=n,
+        completion_tokens=seconds,
     )
 
-    for idx, video_id in enumerate(video_ids, start=1):
-        video_bytes = await client.get_video_content(video_id)
+    for idx, video_generation in enumerate(video_generations, start=1):
+        video_bytes = await client.get_video_content(video_generation.id)
         content_type = "video/mp4"
 
         if storage:
@@ -212,7 +214,7 @@ async def chat_completion(
                     client=client,
                 )
 
-                video_ids = await _poll_job(
+                video_generations = await _poll_job(
                     stage=stage,
                     client=client,
                     job_id=job_id,
@@ -224,7 +226,7 @@ async def chat_completion(
                     choice=choice,
                     storage=file_storage,
                     client=client,
-                    video_ids=video_ids,
+                    video_generations=video_generations,
                 )
 
     stream = response._generate_stream(_handler)

--- a/aidial_adapter_openai/video_generation/azure/types.py
+++ b/aidial_adapter_openai/video_generation/azure/types.py
@@ -23,6 +23,7 @@ class VideoGeneration(BaseModel):
     """
 
     id: str
+    n_seconds: int
 
 
 class MediaItemType(str, Enum):

--- a/tests/integration_tests/test_video_generation.py
+++ b/tests/integration_tests/test_video_generation.py
@@ -85,7 +85,7 @@ async def test_text_to_video_multiple_variants(
     videogen_deployment: D,
     stream: bool,
 ) -> None:
-    config = {"n_seconds": 1, "n_variants": 2}
+    config = {"n_seconds": 2, "n_variants": 2}
     query = "a cat with octopus tentacles riding a bike on Mars"
 
     response = await chat_completion(
@@ -98,7 +98,7 @@ async def test_text_to_video_multiple_variants(
 
     assert response.usage is not None
     assert response.usage.prompt_tokens == 0
-    assert response.usage.completion_tokens == 2
+    assert response.usage.completion_tokens == 4
 
     for attachments in response.all_attachments:
         video_attachments = [


### PR DESCRIPTION
Reporting the overall number of **seconds** in generated video(s) in `usage.completion_tokens` rather than simply the overall **number** of generated video(s). It's better, but still not entirely in line with how Azure is pricing requests to Sora.

In Azure the price depends on both the number of **seconds** and the **resolution** of the video.
Moreover, neither is scaling linearly:

### Sora (1)

<img width="1342" height="1020" alt="image" src="https://github.com/user-attachments/assets/148e8b5a-e609-4301-902d-b4b6805c2d0a" />

### Sora 2

<img width="2104" height="832" alt="image" src="https://github.com/user-attachments/assets/dea6cdff-5cd6-4e2e-9c36-6285fcacafb2" />
