### PR TITLE
fix: Sora: propagate errors from the upstream

### DIFF
--- a/aidial_adapter_openai/exception_handlers.py
+++ b/aidial_adapter_openai/exception_handlers.py
@@ -1,6 +1,8 @@
 import re
+from functools import wraps
 
 import fastapi
+import httpx
 from aidial_sdk.exceptions import HTTPException as DialException
 from aidial_sdk.exceptions import InternalServerError
 from fastapi.requests import Request as FastAPIRequest
@@ -24,6 +26,15 @@ def _convert_to_adapter_exception(exc: Exception) -> AdapterException:
 
     if isinstance(exc, (DialException, ResponseWrapper)):
         return exc
+
+    if isinstance(exc, httpx.HTTPStatusError):
+        r = exc.response
+        if ret := parse_adapter_exception(
+            status_code=r.status_code,
+            headers={},
+            content=r.text,
+        ):
+            return ret
 
     if isinstance(exc, APIStatusError):
         # Non-streaming errors are reported by `openai` library via this exception
@@ -133,3 +144,27 @@ def adapter_exception_handler(
         exc_info=e,
     )
     return adapter_exception.to_fastapi_response()
+
+
+def _to_dial_exception(exc: Exception) -> DialException:
+    exc = to_adapter_exception(exc)
+    if isinstance(exc, ResponseWrapper):
+        return exc.to_dial_exception()
+    else:
+        return exc
+
+
+def dial_exception_decorator(func):
+    @wraps(func)
+    async def wrapper(*args, **kwargs):
+        try:
+            return await func(*args, **kwargs)
+        except Exception as e:
+            dial_exception = _to_dial_exception(e)
+            logger.exception(
+                f"Caught exception: {type(e).__module__}.{type(e).__name__}. "
+                f"The exception converted to the dial exception: {dial_exception!r}."
+            )
+            raise dial_exception from e
+
+    return wrapper

--- a/aidial_adapter_openai/utils/adapter_exception.py
+++ b/aidial_adapter_openai/utils/adapter_exception.py
@@ -46,6 +46,13 @@ class ResponseWrapper(Exception):
             }
         }
 
+    def to_dial_exception(self) -> DialException:
+        return DialException(
+            status_code=self.status_code,
+            message=self.content,
+            headers=dict(self.headers or {}),
+        )
+
 
 AdapterException = ResponseWrapper | DialException
 

--- a/aidial_adapter_openai/video_generation/azure/adapter.py
+++ b/aidial_adapter_openai/video_generation/azure/adapter.py
@@ -14,6 +14,7 @@ from httpx._types import RequestFiles
 
 from aidial_adapter_openai.dial_api.request import parse_configuration
 from aidial_adapter_openai.dial_api.storage import DIAL_URL, FileStorage
+from aidial_adapter_openai.exception_handlers import dial_exception_decorator
 from aidial_adapter_openai.utils.auth import OpenAICreds
 from aidial_adapter_openai.utils.log_config import logger
 from aidial_adapter_openai.video_generation.azure.client import (
@@ -192,6 +193,7 @@ async def chat_completion(
 
     client = AzureVideoAPIClient(creds=creds, base_url=upstream_endpoint)
 
+    @dial_exception_decorator
     async def _handler(request: DIALRequest, response: DIALResponse) -> None:
         response.set_model(model_name)
 

--- a/aidial_adapter_openai/video_generation/azure/client.py
+++ b/aidial_adapter_openai/video_generation/azure/client.py
@@ -45,7 +45,7 @@ class VideoGenerationJob(BaseModel):
                     code="content_filter", message=message
                 )
 
-        raise _internal_server_error(message)
+        raise InternalServerError(message=message)
 
 
 class AzureVideoAPIClient(BaseModel):
@@ -91,10 +91,7 @@ class AzureVideoAPIClient(BaseModel):
             files=files,
             **client_options,
         )
-        if not resp.is_success:
-            raise _internal_server_error(
-                "Video generation job creation failed", resp
-            )
+        resp.raise_for_status()
 
         resp_body = resp.json()
         logger.debug(f"job created: {json.dumps(resp_body)}")
@@ -104,11 +101,7 @@ class AzureVideoAPIClient(BaseModel):
         url = f"{self.base_url}/jobs/{job_id}"
 
         resp = await get_http_client().get(url=url, **self._client_options)
-
-        if not resp.is_success:
-            raise _internal_server_error(
-                "Getting the status of a video generation job failed", resp
-            )
+        resp.raise_for_status()
 
         resp_body = resp.json()
         logger.debug(f"job status polled: {json.dumps(resp_body)}")
@@ -118,20 +111,5 @@ class AzureVideoAPIClient(BaseModel):
         url = f"{self.base_url}/{generation_id}/content/video"
 
         resp = await get_http_client().get(url=url, **self._client_options)
-
-        if not resp.is_success:
-            raise _internal_server_error(
-                "Fetching generated video content failed", resp
-            )
-
+        resp.raise_for_status()
         return resp.content
-
-
-def _internal_server_error(
-    message: str, response: httpx.Response | None = None
-) -> InternalServerError:
-    if response:
-        logger.error(f"{message}: {response.status_code} {response.text}")
-    else:
-        logger.error(message)
-    return InternalServerError(message=message)


### PR DESCRIPTION
**Before the fix**: 404 error from the upstream was resulting in 500 error from the adapter. Besides not being very helpful feedback, this leads to retries in a typical OpenAI client (`openai` or `langchain`).
**After the fix**: 404 error from the upstream is propagated as 404 error from the adapter.