### PR TITLE
fix: Whisper: support streaming mode

### DIFF
--- a/aidial_adapter_openai/audio_api/transcribe/adapter.py
+++ b/aidial_adapter_openai/audio_api/transcribe/adapter.py
@@ -119,6 +119,23 @@ async def chat_completion(
         async def _gen() -> AsyncIterator[dict]:
             yield create_chunk(role="assistant")
 
+            if "application/json" in response.response.headers["content-type"]:
+                # Special handling of the Whisper model.
+                # It ignores stream=true parameter and returns block response.
+                response_bytes = await response.response.aread()
+
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(f"raw response: {response_bytes!r}")
+
+                resp = TranscriptionVerbose.parse_raw(response_bytes)
+
+                yield create_chunk(
+                    content=resp.text,
+                    usage=_get_usage(resp),
+                    finish_reason="stop",
+                )
+                return
+
             async for chunk in response:
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.debug(f"response chunk: {chunk.json()}")

--- a/aidial_adapter_openai/audio_api/transcribe/prompt.py
+++ b/aidial_adapter_openai/audio_api/transcribe/prompt.py
@@ -58,9 +58,12 @@ class TranscribePrompt(BaseModel):
                     audios.append(file)
 
         if not audios:
-            raise RequestValidationError(
-                "No audio attachment found in the last message"
-            )
+            msg = "No audio attachment found in the last message"
+            raise RequestValidationError(message=msg, display_message=msg)
+
+        if len(audios) > 1:
+            msg = "No more than one audio attachment is expected in the last message"
+            raise RequestValidationError(message=msg, display_message=msg)
 
         audio = audios[0]
         audio_data, audio_type = (audio.resource.data, audio.resource.type)

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -41,6 +41,8 @@ def create_test_cases(
             if (
                 not deployment.model_features.imageGenerationSupported
                 and not deployment.supports_video_generation
+                and not deployment.supports_tts
+                and not deployment.supports_stt
             ):
                 suite = TestSuite(deployment, streaming)
                 for builder in builders:


### PR DESCRIPTION
Whisper doesn't support `stream=true`, therefore, the following configuration is required

```ini
NON_STREAMING_DEPLOYMENTS=whisper
```

After the fix, **this configuration isn't needed**, since the adapter itself checks `content-type` response header and understands whether it's a streaming response or a block response.

Also improved user-facing errors in case when an audio attachment isn't provided or provided more than one attachment.