### PR TITLE
fix: Dall-E-3: prevent user prompts leaking to error messages

### DIFF
--- a/aidial_adapter_openai/exception_handlers.py
+++ b/aidial_adapter_openai/exception_handlers.py
@@ -90,6 +90,14 @@ def _convert_to_adapter_exception(exc: Exception) -> AdapterException:
     return InternalServerError(str(exc))
 
 
+def _truncate_long_string(s: str, *, limit: int) -> str:
+    if (excess := len(s) - limit) > 0:
+        ln = limit // 2
+        rn = limit - ln
+        return s[:ln] + f"<truncated {excess} characters>" + s[-rn:]
+    return s
+
+
 def _expose_error_message_to_user(exc: AdapterException) -> AdapterException:
     if isinstance(exc, DialException) and exc.status_code == 400:
         message = exc.message
@@ -118,6 +126,22 @@ def _expose_error_message_to_user(exc: AdapterException) -> AdapterException:
                 exc.display_message
                 or "The provided image attachment is either corrupt or of unsupported MIME type."
             )
+
+        # Special handling of GPT Image 1 exception when the prompt is too long
+        if "Invalid 'prompt': string too long" in message:
+            exc.display_message = (
+                exc.display_message or "The prompt is too long."
+            )
+
+        # Special handling of DALL·E 3 exception when the prompt is too long
+        if "is too long - 'prompt'" in message:
+            # DALL·E 3 is notorious for including the whole prompt in the error message,
+            # therefore, we override it with a short one.
+            exc.message = "The prompt is too long."
+            exc.display_message = exc.display_message or exc.message
+
+        # Just in case any other sensitive information leaked to the error message, we truncate it
+        exc.message = _truncate_long_string(exc.message, limit=1024)
 
     return exc
 

--- a/tests/integration_tests/test_image_generation.py
+++ b/tests/integration_tests/test_image_generation.py
@@ -160,3 +160,48 @@ async def test_image_to_image(
     )
 
     assert "space" in evaluation.content.lower()
+
+
+async def test_imagen_prompt_is_too_long(
+    create_openai_client: Callable[..., openai.AsyncAzureOpenAI],
+    imagen_deployment: D,
+    stream: bool,
+):
+    long_prompt = "cat on a sofa" * 100_000
+
+    with pytest.raises(openai.BadRequestError) as exc_info:
+        await chat_completion(
+            create_openai_client(imagen_deployment),
+            stream=stream,
+            deployment_id=imagen_deployment.model_name,
+            messages=[user(long_prompt)],
+        )
+
+    exc = exc_info.value
+    assert exc.status_code == 400
+
+    error_message = exc.message
+    assert len(error_message) <= 512, (
+        f"The error message is too long: {len(error_message)}. "
+        "Most likely the whole prompt leaked to the error message."
+    )
+
+    error_body = exc.body or {}
+
+    if imagen_deployment.type_ == ChatCompletionDeploymentType.DALLE3:
+        assert error_body == {
+            "type": "invalid_request_error",
+            "code": "invalidPayload",
+            "message": "The prompt is too long.",
+            "display_message": "The prompt is too long.",
+        }
+    elif imagen_deployment.type_ == ChatCompletionDeploymentType.GPT_IMAGE_1:
+        assert error_body == {
+            "type": "invalid_request_error",
+            "param": "prompt",
+            "code": "string_above_max_length",
+            "message": "Invalid 'prompt': string too long. Expected a string with maximum length 32000, but got a string with length 1300000 instead.",
+            "display_message": "The prompt is too long.",
+        }
+    else:
+        assert False, f"Unexpected deployment type: {imagen_deployment.type_}"


### PR DESCRIPTION
Resolves https://github.com/epam/ai-dial-adapter-openai/issues/289

**Error before**: 

> HTTPException(message=''the-whose-user-prompt' is too long - 'prompt'', status_code=400, type='invalid_request_error', param=None, code='invalidPayload', display_message=None)

**Error after**:

> HTTPException(message='The prompt is too long.', status_code=400, type='invalid_request_error', param=None, code='invalidPayload', display_message='The prompt is too long.')

Also 
* setting `display_message='The prompt is too long.'` for prompt-is-too-long errors for GPT Image 1 models too.
* truncating error message to 1024 characters for all 400 exceptions