### PR TITLE
fix: convert `rate_limit_exceeded` error chunk code to 429 HTTP status code

### DIFF
--- a/aidial_adapter_openai/endpoints/chat_completion.py
+++ b/aidial_adapter_openai/endpoints/chat_completion.py
@@ -193,7 +193,7 @@ async def chat_completion(deployment_id: str, request: Request):
 
     api_version = get_api_version(request)
 
-    return create_server_response(
+    return await create_server_response(
         emulate_streaming,
         await call_chat_completion(
             deployment_id=deployment_id,

--- a/aidial_adapter_openai/exception_handlers.py
+++ b/aidial_adapter_openai/exception_handlers.py
@@ -80,6 +80,8 @@ def _convert_to_adapter_exception(exc: Exception) -> AdapterException:
                 status_code = int(exc.code)
             except Exception:
                 pass
+            if exc.code == "rate_limit_exceeded":
+                status_code = 429
 
         return parse_adapter_exception(
             status_code=status_code,

--- a/aidial_adapter_openai/exception_handlers.py
+++ b/aidial_adapter_openai/exception_handlers.py
@@ -101,7 +101,10 @@ def _truncate_long_string(s: str, *, limit: int) -> str:
 def _expose_error_message_to_user(exc: AdapterException) -> AdapterException:
     if isinstance(exc, DialException) and exc.status_code == 400:
         message = exc.message
-        if "this model does not support file content types" in message.lower():
+        if (
+            "this model does not support file content types" in message.lower()
+            or "the file type you uploaded is not supported" in message.lower()
+        ):
             exc.display_message = (
                 exc.display_message
                 or "The provided file attachments aren't supported."

--- a/aidial_adapter_openai/utils/sse_stream.py
+++ b/aidial_adapter_openai/utils/sse_stream.py
@@ -1,8 +1,7 @@
 import json
 from typing import Any, AsyncIterator, Mapping
 
-from aidial_adapter_openai.exception_handlers import to_adapter_exception
-from aidial_adapter_openai.utils.log_config import logger
+from aidial_adapter_openai.utils.adapter_exception import AdapterException
 
 _DATA_PREFIX = "data: "
 _OPENAI_END_MARKER = "[DONE]"
@@ -19,19 +18,11 @@ _END_CHUNK = _format_chunk(_OPENAI_END_MARKER)
 
 
 async def to_openai_sse_stream(
-    stream: AsyncIterator[dict],
+    stream: AsyncIterator[dict | AdapterException],
 ) -> AsyncIterator[str]:
-    try:
-        async for chunk in stream:
+    async for chunk in stream:
+        if isinstance(chunk, Exception):
+            yield _format_chunk(chunk.json_error())
+        else:
             yield _format_chunk(chunk)
-    except Exception as e:
-        adapter_exception = to_adapter_exception(e)
-
-        logger.exception(
-            f"Caught exception while streaming: {type(e).__module__}.{type(e).__name__}. "
-            f"Converted to the adapter exception: {adapter_exception!r}"
-        )
-
-        yield _format_chunk(adapter_exception.json_error())
-
     yield _END_CHUNK

--- a/aidial_adapter_openai/utils/streaming.py
+++ b/aidial_adapter_openai/utils/streaming.py
@@ -9,6 +9,7 @@ from typing import (
     List,
     Optional,
     Set,
+    Tuple,
     TypeVar,
 )
 from uuid import uuid4
@@ -21,6 +22,8 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 from pydantic import BaseModel
 
+from aidial_adapter_openai.exception_handlers import to_adapter_exception
+from aidial_adapter_openai.utils.adapter_exception import AdapterException
 from aidial_adapter_openai.utils.chat_completion_response import (
     ChatCompletionResponse,
     ChatCompletionStreamingChunk,
@@ -240,7 +243,7 @@ _BaseResponse = AsyncIterator[dict] | dict | BaseModel
 AppResponse = ResponseWithHeaders[_BaseResponse] | _BaseResponse | Response
 
 
-def create_server_response(
+async def create_server_response(
     emulate_streaming: bool, response: AppResponse
 ) -> Response:
     if isinstance(response, ResponseWithHeaders):
@@ -256,27 +259,33 @@ def create_server_response(
 
         return stream()
 
-    def stream_to_response(stream: AsyncIterator[dict]) -> Response:
-        return StreamingResponse(
-            to_openai_sse_stream(stream),
-            media_type="text/event-stream",
-            headers=headers,
-        )
+    async def stream_to_response(iterator: AsyncIterator[dict]) -> Response:
+        item, stream = await peek_head(reify_exceptions(iterator))
 
-    def block_to_response(block: dict) -> Response:
+        if isinstance(item, Exception):
+            return item.to_fastapi_response()
+        else:
+            content = to_openai_sse_stream(prepend(item, stream))
+            return StreamingResponse(
+                content=content,
+                media_type="text/event-stream",
+                headers=headers,
+            )
+
+    async def block_to_response(block: dict) -> Response:
         if emulate_streaming:
-            return stream_to_response(block_to_stream(block))
+            return await stream_to_response(block_to_stream(block))
         else:
             return JSONResponse(block, headers=headers)
 
     if isinstance(body, AsyncIterator):
-        return stream_to_response(body)
+        return await stream_to_response(body)
 
     if isinstance(body, dict):
-        return block_to_response(body)
+        return await block_to_response(body)
 
     if isinstance(body, BaseModel):
-        return block_to_response(body.dict())
+        return await block_to_response(body.dict())
 
     return body
 
@@ -300,6 +309,42 @@ async def map_stream(
         new_item = func(item)
         if new_item is not None:
             yield new_item
+
+
+async def prepend(
+    value: T | None, iterator: AsyncIterator[T]
+) -> AsyncIterator[T]:
+    if value is not None:
+        yield value
+    async for item in iterator:
+        yield item
+
+
+async def peek_head(
+    iterator: AsyncIterator[T],
+) -> Tuple[T | None, AsyncIterator[T]]:
+    try:
+        val = await iterator.__anext__()
+        return val, iterator
+    except StopAsyncIteration:
+        return None, iterator
+
+
+async def reify_exceptions(
+    stream: AsyncIterator[dict],
+) -> AsyncIterator[dict | AdapterException]:
+    try:
+        async for chunk in stream:
+            yield chunk
+    except Exception as e:
+        adapter_exception = to_adapter_exception(e)
+
+        logger.exception(
+            f"Caught exception while streaming: {type(e).__module__}.{type(e).__name__}. "
+            f"Converted to the adapter exception: {adapter_exception!r}"
+        )
+
+        yield adapter_exception
 
 
 def debug_print(title: str, chunk: dict) -> None:

--- a/tests/integration_tests/chat_completion/file_input.py
+++ b/tests/integration_tests/chat_completion/file_input.py
@@ -59,6 +59,6 @@ def build_file_input_common(s: TestSuite) -> None:
         ],
         expected=ExpectedException(
             type=openai.BadRequestError,
-            display_message=f"The file attachments of the MIME type '{UNSUPPORTED_DOCUMENT_RESOURCE.type}' aren't supported.",
+            display_message=r"The file attachments of the MIME type '.*' aren't supported|The provided file attachments aren't supported",
         ),
     )

--- a/tests/integration_tests/integration_test_config_example.json
+++ b/tests/integration_tests/integration_test_config_example.json
@@ -116,6 +116,26 @@
                 "image/*"
             ]
         },
+        "gpt-5.2-2025-12-11": {
+            "overrideName": "gpt-5.2",
+            "type": "chat",
+            "upstreams": [
+                {
+                    "endpoint": "https://azure-foundry-name.cognitiveservices.azure.com/openai/v1/responses",
+                    "key": "optional-api-key"
+                }
+            ],
+            "features": {
+                "parallelToolCallsSupported": false,
+                "maxTokensSupported": false,
+                "reasoningSupported": true,
+                "stopSupported": false,
+                "temperatureSupported": false
+            },
+            "inputAttachmentTypes": [
+                "image/*"
+            ]
+        },
         "gpt-4-turbo-2024-04-09": {
             "type": "chat",
             "upstreams": [
@@ -346,16 +366,6 @@
         },
         "sora": {
             "overrideName": "sora",
-            "type": "chat",
-            "upstreams": [
-                {
-                    "endpoint": "https://azure-foundry-name.cognitiveservices.azure.com/openai/v1/video/generations",
-                    "key": "optional-api-key"
-                }
-            ]
-        },
-        "sora-2": {
-            "overrideName": "sora-2",
             "type": "chat",
             "upstreams": [
                 {

--- a/tests/unit_tests/test_errors.py
+++ b/tests/unit_tests/test_errors.py
@@ -5,6 +5,10 @@ from unittest.mock import patch
 import httpx
 import pytest
 import respx
+from openai.types.responses.response import Response
+from openai.types.responses.response_in_progress_event import (
+    ResponseInProgressEvent,
+)
 from respx.types import SideEffectTypes
 
 from aidial_adapter_openai.configuration.app_config import ApplicationConfig
@@ -1167,36 +1171,23 @@ async def test_rate_limit_exceeded_during_streaming():
 
     upstream_url = "http://test-upstream.com/openai/v1/responses"
 
-    mock_event = {
-        "type": "response.in_progress",
-        "sequence_number": 1,
-        "response": {
-            "id": "resp_01f342feea0be5f60069419a50a74c81908afe72661bbd3112",
-            "created_at": 1765907024.0,
-            "metadata": {},
-            "model": "gpt-5.2-2025-12-11",
-            "object": "response",
-            "output": [],
-            "parallel_tool_calls": True,
-            "temperature": 1.0,
-            "tool_choice": "auto",
-            "tools": [],
-            "top_p": 0.98,
-            "background": False,
-            "reasoning": {
-                "effort": "none",
-            },
-            "service_tier": "auto",
-            "status": "in_progress",
-            "text": {"format": {"type": "text"}, "verbosity": "medium"},
-            "truncation": "disabled",
-            "store": True,
-            "top_logprobs": 0,
-        },
-    }
+    mock_event = ResponseInProgressEvent(
+        sequence_number=1,
+        type="response.in_progress",
+        response=Response(
+            id="resp_id",
+            object="response",
+            created_at=1765907024.0,
+            model="upstream-model-id",
+            output=[],
+            parallel_tool_calls=True,
+            tool_choice="auto",
+            tools=[],
+        ),
+    )
 
     mock_stream = OpenAIStream(
-        mock_event,
+        mock_event.dict(),
         {
             "error": {
                 "message": "no_kv_space",
@@ -1220,7 +1211,7 @@ async def test_rate_limit_exceeded_during_streaming():
             json={
                 "model": "upstream-model-id",
                 "messages": [{"role": "user", "content": "test"}],
-                "stream": "True",
+                "stream": True,
             },
             headers={
                 "X-UPSTREAM-KEY": "dummy-upstream-api-key",

--- a/tests/unit_tests/test_errors.py
+++ b/tests/unit_tests/test_errors.py
@@ -144,8 +144,8 @@ async def test_top_level_extra_field(test_app: httpx.AsyncClient):
         },
     )
 
-    assert response.status_code == 200
-    mock_stream.assert_response_content(response, assert_equal)
+    assert response.status_code == 500
+    assert response.json() == {"error": {"message": "whatever", "code": "500"}}
 
 
 @respx.mock
@@ -185,8 +185,8 @@ async def test_nested_extra_field(test_app: httpx.AsyncClient):
         },
     )
 
-    assert response.status_code == 200
-    mock_stream.assert_response_content(response, assert_equal)
+    assert response.status_code == 500
+    assert response.json() == {"error": {"message": "whatever", "code": "500"}}
 
 
 @respx.mock
@@ -768,15 +768,14 @@ async def test_invalid_chunk_stream_from_upstream(
         },
     )
 
-    assert response.status_code == 200
-    assert response.text == "\n\n".join(
-        [
-            # OpenAI is unable to parse SSE entry with invalid JSON and fails with the following error:
-            'data: {"error":{"message":"Expecting value: line 1 column 1 (char 0)","type":"internal_server_error","code":"500"}}',
-            "data: [DONE]",
-            "",
-        ]
-    )
+    assert response.status_code == 500
+    assert response.json() == {
+        "error": {
+            "message": "Expecting value: line 1 column 1 (char 0)",
+            "type": "internal_server_error",
+            "code": "500",
+        }
+    }
 
 
 @respx.mock

--- a/tests/unit_tests/test_errors.py
+++ b/tests/unit_tests/test_errors.py
@@ -1228,7 +1228,7 @@ async def test_rate_limit_exceeded_during_streaming():
             },
         )
 
-        assert response.status_code == 500
+        assert response.status_code == 429
         assert response.json() == {
             "error": {
                 "code": "rate_limit_exceeded",

--- a/tests/unit_tests/test_errors.py
+++ b/tests/unit_tests/test_errors.py
@@ -1156,3 +1156,84 @@ async def test_error_invalid_image_url(stream: bool):
                 "code": "400",
             }
         }
+
+
+@respx.mock
+async def test_rate_limit_exceeded_during_streaming():
+    app_config = (
+        ApplicationConfig()
+        .add_deployment("app", ChatCompletionDeploymentType.RESPONSES_API)
+        .map_to_tiktoken_model("app", "gpt-4")
+    )
+
+    upstream_url = "http://test-upstream.com/openai/v1/responses"
+
+    mock_event = {
+        "type": "response.in_progress",
+        "sequence_number": 1,
+        "response": {
+            "id": "resp_01f342feea0be5f60069419a50a74c81908afe72661bbd3112",
+            "created_at": 1765907024.0,
+            "metadata": {},
+            "model": "gpt-5.2-2025-12-11",
+            "object": "response",
+            "output": [],
+            "parallel_tool_calls": True,
+            "temperature": 1.0,
+            "tool_choice": "auto",
+            "tools": [],
+            "top_p": 0.98,
+            "background": False,
+            "reasoning": {
+                "effort": "none",
+            },
+            "service_tier": "auto",
+            "status": "in_progress",
+            "text": {"format": {"type": "text"}, "verbosity": "medium"},
+            "truncation": "disabled",
+            "store": True,
+            "top_logprobs": 0,
+        },
+    }
+
+    mock_stream = OpenAIStream(
+        mock_event,
+        {
+            "error": {
+                "message": "no_kv_space",
+                "type": "server_error",
+                "code": "rate_limit_exceeded",
+            }
+        },
+    )
+
+    respx.post("http://test-upstream.com/openai/v1/responses").mock(
+        side_effect=mock_response(
+            status_code=200,
+            content_type="text/event-stream",
+            content=mock_stream.to_content(),
+        )
+    )
+
+    async with create_test_client(app_config=app_config) as http_client:
+        response = await http_client.post(
+            "/openai/deployments/app/chat/completions?api-version=2023-03-15-preview",
+            json={
+                "model": "upstream-model-id",
+                "messages": [{"role": "user", "content": "test"}],
+                "stream": "True",
+            },
+            headers={
+                "X-UPSTREAM-KEY": "dummy-upstream-api-key",
+                "X-UPSTREAM-ENDPOINT": upstream_url,
+            },
+        )
+
+        assert response.status_code == 500
+        assert response.json() == {
+            "error": {
+                "code": "rate_limit_exceeded",
+                "message": "no_kv_space",
+                "type": "server_error",
+            }
+        }


### PR DESCRIPTION
Certain GPT-5.2 deployments return `rate_limit_exceeded` error code during streaming, instead of returning 429 response straight away _(see a [couple](https://github.com/openai/codex/issues/7967) of [relevant](https://www.reddit.com/r/dotnet/comments/1pkr9sz/the_new_gpt52_on_azure_threw_a_stack_trace_at_me/) [issues](https://github.com/sst/opencode/issues/5526), albeit not in official Azure repos)_.

This results in streaming responses with 200 status code and a single error chunk:

```json
{
  "error": {
    "message": " | ==================== d002-20251211012732-api-default-6df7cd85-bk8d4 ====================\n | Traceback (most recent call last):\n | \n |   File \"/usr/local/lib/python3.12/site-packages/inference_server/routes.py\", line 726, in streaming_completion\n |     await response.write_to(reactor)\n | \n | oai_grpc.errors.ServerError:  | no_kv_space\n | ",
    "type": "server_error",
    "code": "rate_limit_exceeded"
  }
}
```

This PR fixes two problems:
1. The adapter inspects the first chunk in the generated stream of chunks, and if it's an error chunk, then it returns a non-streaming response.
2. The adapter inspects the error chunk's `code` field and if it's equal to `rate_limit_exceeded` it sets the status code of the HTTP response equal to 429.

This makes the 429 status code visible to DIAL Core, so it's able to retry the request with another upstream. This wasn't possible previously, since DIAL Core was receiving a 200 status code with an error chunk in it.

---

For the context the original adapter logs highligthing the issue:

<details>
<summary>Adapter's logs</summary>

```txt
ERROR    aidial_adapter_openai:sse_stream.py:30 Caught exception while streaming: openai.APIError. Converted to the adapter exception: HTTPException(message=' | ==================== d002-20251211012732-api-default-6df7cd85-bk8d4 ====================\n | Traceback (most recent call last):\n | \n |   File "/usr/local/lib/python3.12/site-packages/inference_server/routes.py", line 726, in streaming_completion\n |     await response.write_to(reactor)\n | \n | oai_grpc.errors.ServerError:  | no_kv_space\n | ', status_code=500, type='server_error', param=None, code='rate_limit_exceeded', display_message=None)
Traceback (most recent call last):
  File "/ai-dial-adapter-openai/aidial_adapter_openai/utils/sse_stream.py", line 25, in to_openai_sse_stream
    async for chunk in stream:
  File "/ai-dial-adapter-openai/aidial_adapter_openai/utils/streaming.py", line 299, in map_stream
    async for item in iterator:
  File "/ai-dial-adapter-openai/aidial_adapter_openai/utils/streaming.py", line 291, in map_stream_generator
    async for item in iterator:
  File "/ai-dial-adapter-openai/.venv/lib/python3.11/site-packages/openai/_streaming.py", line 147, in __aiter__
    async for item in self._iterator:
  File "/ai-dial-adapter-openai/.venv/lib/python3.11/site-packages/openai/_streaming.py", line 193, in __stream__
    raise APIError(
openai.APIError:  | ==================== d002-20251211012732-api-default-6df7cd85-bk8d4 ====================
 | Traceback (most recent call last):
 |
 |   File "/usr/local/lib/python3.12/site-packages/inference_server/routes.py", line 726, in streaming_completion
 |     await response.write_to(reactor)
 |
 | oai_grpc.errors.ServerError:  | no_kv_space
 |
INFO     httpx:_client.py:1773 HTTP Request: POST http://test-app.com/openai/deployments/gpt-5.2-2025-12-11/chat/completions?api-version=2024-12-01-preview "HTTP/1.1 200 OK"
```

</details>