### PR TITLE
feat: enable support of private CAs or self-signed certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ FROM python:3.11-alpine AS server
 
 RUN apk update && apk upgrade --no-cache libcrypto3 libssl3
 
+# Updating the system CA bundle at /etc/ssl/certs/ca-certificates.crt
+RUN apk add --no-cache ca-certificates && update-ca-certificates
+
 # fix CVE-2023-52425
 RUN apk upgrade --no-cache libexpat
 # fix CVE-2025-47273
@@ -35,6 +38,9 @@ WORKDIR /app
 # Copy the sources and virtual env. No poetry.
 RUN adduser -u 1001 --disabled-password --gecos "" appuser
 COPY --chown=appuser --from=builder /app .
+
+COPY ./scripts/__cacert_entrypoint.sh /__cacert_entrypoint.sh
+RUN chmod +x /__cacert_entrypoint.sh
 
 COPY ./scripts/docker_entrypoint.sh /docker_entrypoint.sh
 RUN chmod +x /docker_entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@
 - [Prompt caching](#prompt-caching)
 - [API versioning](#api-versioning)
 - [Server performance configuration](#server-performance-configuration)
+- [Deployment](#deployment)
+  - [Private CAs and self-signed certificates](#private-cas-and-self-signed-certificates)
+    - [Docker](#docker)
 - [Development](#development)
   - [Development environment](#development-environment)
   - [IDE configuration](#ide-configuration)
@@ -1047,6 +1050,32 @@ There are two environment variables that control server performance:
 1. `WEB_CONCURRENCY` *(default = 1)* — the number of worker processes spawned by [uvicorn](https://www.uvicorn.org/deployment/#running-from-the-command-line). Workers run independently; the parent uvicorn process handles load balancing across them. The OS schedules workers on different CPU cores, enabling true parallelism. This matters when the server performs CPU-intensive work, primarily request/response [tokenization](#tokenization-of-chat-completion-requestsresponses). For full CPU utilization, set this to the number of **logical CPUs**. However, the default of 1 is fine if you don’t expect much CPU load (see [minimizing tokenization](#how-to-minimize-adapter-side-tokenization)).
 
 2. `THREAD_POOL_SIZE` *(default = logical CPUs + 4)* — the size of the thread pool used for CPU-heavy tasks (currently, only request/response [tokenization](#tokenization-of-chat-completion-requestsresponses)). This effectively caps how many CPU-bound tasks can run simultaneously: no more than `THREAD_POOL_SIZE` at a time. Note that this does not block requests without CPU-heavy work (e.g., health checks or embeddings requests).
+
+---
+
+## Deployment
+
+### Private CAs and self-signed certificates
+
+The Docker container supports trusting private Certificate Authorities (CAs) and self-signed certificates for all outbound TLS connections.
+
+To enable this, provide your CA certificates at runtime and opt in via `USE_SYSTEM_CA_CERTS` environment variable.
+
+#### Docker
+
+Run the container with:
+
+1. `USE_SYSTEM_CA_CERTS` set to any non-empty value,
+2. a directory containing one or more `*.crt` files (PEM format) mounted at `/certificates` (read-only is fine)
+
+```sh
+docker run --rm \
+  -e USE_SYSTEM_CA_CERTS=1 \
+  -v "$PWD/certs:/certificates:ro" \
+  epam/ai-dial-adapter-openai:development
+```
+
+When enabled, the container builds a temporary trust store on startup that combines the system CA bundle with all certificates found in `/certificates/*.crt`.
 
 ---
 

--- a/scripts/__cacert_entrypoint.sh
+++ b/scripts/__cacert_entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -e
+
+if [ -n "${USE_SYSTEM_CA_CERTS:-}" ]; then
+  TMPDIR="/tmp"
+  SYSTEM_BUNDLE="/etc/ssl/certs/ca-certificates.crt"
+
+  if [ ! -w "$TMPDIR" ]; then
+    echo "Using additional CA certificates requires write permissions to $TMPDIR."
+    exit 1
+  fi
+
+  if [ ! -r "$SYSTEM_BUNDLE" ]; then
+    echo "System CA bundle not found at $SYSTEM_BUNDLE (did you install ca-certificates?)."
+    exit 1
+  fi
+
+  OUT_BUNDLE="$(mktemp "${TMPDIR}/ca-bundle.XXXXXX")"
+
+  # Append the system trust store
+  cat "$SYSTEM_BUNDLE" > "$OUT_BUNDLE"
+
+  # Append mounted custom certs
+  if [ -d /certificates ]; then
+    for f in /certificates/*.crt; do
+      [ -f "$f" ] || continue
+      echo >> "$OUT_BUNDLE"
+      cat "$f" >> "$OUT_BUNDLE"
+    done
+  fi
+
+  # Tell Python HTTP client (httpx) to use the merged bundle
+  export SSL_CERT_FILE="$OUT_BUNDLE"
+  echo "Using CA bundle at $OUT_BUNDLE"
+fi

--- a/scripts/__cacert_entrypoint.sh
+++ b/scripts/__cacert_entrypoint.sh
@@ -6,16 +6,19 @@ if [ -n "${USE_SYSTEM_CA_CERTS:-}" ]; then
   SYSTEM_BUNDLE="/etc/ssl/certs/ca-certificates.crt"
 
   if [ ! -w "$TMPDIR" ]; then
-    echo "Using additional CA certificates requires write permissions to $TMPDIR."
+    echo "Using additional CA certificates requires write permissions to $TMPDIR." >&2
     exit 1
   fi
 
   if [ ! -r "$SYSTEM_BUNDLE" ]; then
-    echo "System CA bundle not found at $SYSTEM_BUNDLE (did you install ca-certificates?)."
+    echo "System CA bundle not found at $SYSTEM_BUNDLE (did you install ca-certificates?)." >&2
     exit 1
   fi
 
-  OUT_BUNDLE="$(mktemp "${TMPDIR}/ca-bundle.XXXXXX")"
+  OUT_BUNDLE="$(mktemp "${TMPDIR}/ca-bundle.XXXXXX")" || {
+    echo "Failed to create temp CA bundle in $TMPDIR" >&2
+    exit 1
+  }
 
   # Append the system trust store
   cat "$SYSTEM_BUNDLE" > "$OUT_BUNDLE"

--- a/scripts/docker_entrypoint.sh
+++ b/scripts/docker_entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+# Load extra CAs (opt-in via USE_SYSTEM_CA_CERTS)
+# This must be sourced so exports apply to this shell.
+. /__python_cacerts.sh
+
 . ./.venv/bin/activate
 
 # If no args passed to `docker run`,

--- a/scripts/docker_entrypoint.sh
+++ b/scripts/docker_entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 # Load extra CAs (opt-in via USE_SYSTEM_CA_CERTS)
 # This must be sourced so exports apply to this shell.
-. /__python_cacerts.sh
+. /__cacert_entrypoint.sh
 
 . ./.venv/bin/activate
 


### PR DESCRIPTION
Similarly to https://github.com/epam/ai-dial-core/pull/1007, to enable the private CAs one needs to:

1. set `USE_SYSTEM_CA_CERTS` env var to any non-empty value,
2. mount `*.crt` files into `/certificates` folder in the Docker container:

```sh
docker run --rm -it \
  -e USE_SYSTEM_CA_CERTS=1 \
  -v "$PWD/certs:/certificates:ro" \
  epam/ai-dial-adapter-openai:development sh
```

<details><summary>How to test it locally</summary>

Run the following from the Adapter OpenAI repository root

1. First console

```sh
mkdir -p certs
cd certs

openssl genrsa -out ca.key 4096

openssl req -x509 -new -nodes -key ca.key \
  -sha256 -days 3650 \
  -out ca.crt \
  -subj "/C=US/O=Test Corp/CN=Test Root CA"

openssl genrsa -out server.key 2048

openssl req -new -key server.key \
  -out server.csr \
  -subj "/C=US/O=Test Corp/CN=localhost"

cat > san.cnf <<'EOF'
subjectAltName=DNS:localhost,DNS:host.docker.internal,IP:127.0.0.1
EOF

openssl x509 -req \
  -in server.csr \
  -CA ca.crt \
  -CAkey ca.key \
  -CAcreateserial \
  -out server.crt \
  -days 825 -sha256 \
  -extfile san.cnf

cat > https_server.py <<'EOF'
import http.server
import ssl

server_address = ("127.0.0.1", 4443)

httpd = http.server.HTTPServer(server_address, http.server.SimpleHTTPRequestHandler)

context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
context.load_cert_chain(certfile="server.crt", keyfile="server.key")

httpd.socket = context.wrap_socket(httpd.socket, server_side=True)

print("Serving HTTPS on https://127.0.0.1:4443")
httpd.serve_forever()
EOF

python https_server.py &

openssl s_client -connect 127.0.0.1:4443 -CAfile ca.crt -verify_return_error < /dev/null

if [ $? -eq 0 ]; then
  echo "Success: TLS verified"
else
  echo "Fail: TLS verification failed"
  exit 1
fi

openssl s_client -connect 127.0.0.1:4443 -verify_return_error < /dev/null

if [ $? -ne 0 ]; then
  echo "Success: TLS verification failed as expected"
else
  echo "Fail: TLS verified"
  exit 1
fi
```

2. Second console

```sh
docker build --platform linux/amd64 -t test-openai-image .

docker run --platform linux/amd64 --rm -it \
  -e USE_SYSTEM_CA_CERTS=1 \
  -v "$PWD/certs:/certificates:ro" \
  test-openai-image sh
```

3. Inside the container run the following commands:

```sh
echo "$SSL_CERT_FILE"
head -n 2 "$SSL_CERT_FILE"
ls -la /certificates

python - <<'EOF'
import httpx
r = httpx.get("https://host.docker.internal:4443")
print(r.status_code)
EOF
```

The `httpx.get` call should return 200 status code.

</details>