### PR TITLE
fix: tolerate custom_content equal null in chat completion request

### DIFF
--- a/aidial_adapter_openai/chat_completions/transformation.py
+++ b/aidial_adapter_openai/chat_completions/transformation.py
@@ -160,7 +160,7 @@ class ResourceProcessor(BaseModel):
 
         content = ensure_list_or_str("content", message.get("content") or "")
         custom_content = ensure_dict(
-            "custom_content", message.pop("custom_content", {})
+            "custom_content", message.pop("custom_content", None) or {}
         )
         attachments = ensure_list(
             "attachments", custom_content.get("attachments") or []

--- a/tests/unit_tests/test_errors.py
+++ b/tests/unit_tests/test_errors.py
@@ -1162,6 +1162,55 @@ async def test_error_invalid_image_url(stream: bool):
 
 
 @respx.mock
+async def test_allow_custom_content_null(test_app: httpx.AsyncClient):
+    mock_stream = OpenAIStream(
+        single_choice_chunk(
+            delta={"role": "assistant", "content": "5"},
+            finish_reason="stop",
+        ),
+    )
+
+    respx.post(
+        "http://localhost:5001/openai/deployments/gpt-4/chat/completions?api-version=2023-03-15-preview"
+    ).respond(
+        status_code=200,
+        content_type="text/event-stream",
+        content=mock_stream.to_content(),
+    )
+
+    response = await test_app.post(
+        "/openai/deployments/gpt-4/chat/completions?api-version=2023-03-15-preview",
+        json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Test content",
+                    "custom_content": None,
+                }
+            ],
+            "stream": True,
+        },
+        headers={
+            "X-UPSTREAM-KEY": "TEST_API_KEY",
+            "X-UPSTREAM-ENDPOINT": "http://localhost:5001/openai/deployments/gpt-4/chat/completions",
+        },
+    )
+
+    assert response.status_code == 200
+    mock_stream.assert_response_content(
+        response,
+        assert_equal,
+        usages={
+            0: {
+                "prompt_tokens": 9,
+                "completion_tokens": 1,
+                "total_tokens": 10,
+            }
+        },
+    )
+
+
+@respx.mock
 async def test_rate_limit_exceeded_during_streaming():
     app_config = (
         ApplicationConfig()


### PR DESCRIPTION
Given a chat completion request where `messages[*].custom_content` is `null`:

```json
{
    "messages": [
        {
            "role": "user",
            "content": "hello",
            "custom_content": null,
        }
    ]
}
```

**Before**: the adapter thrown the error `"'custom_content' expected to be dict, but got NoneType"`:

<details> <summary>Error stacktrace</summary>

```txt
ERROR    aidial_adapter_openai:exception_handlers.py:170 Caught exception: aidial_sdk.exceptions.InvalidRequestError. Converted to the adapter exception: InvalidRequestError(message="'custom_content' expected to be dict, but got NoneType", status_code=400, type='invalid_request_error', param=None, code='400', display_message=None)
Traceback (most recent call last):
  File "./.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "./.venv/lib/python3.11/site-packages/fastapi/routing.py", line 110, in app
    response = await f(request)
               ^^^^^^^^^^^^^^^^
  File "./.venv/lib/python3.11/site-packages/fastapi/routing.py", line 390, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./.venv/lib/python3.11/site-packages/fastapi/routing.py", line 289, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./aidial_adapter_openai/endpoints/chat_completion.py", line 207, in chat_completion
    await call_chat_completion(
  File "./aidial_adapter_openai/endpoints/chat_completion.py", line 174, in call_chat_completion
    response = await gpt_chat_completion(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./aidial_adapter_openai/chat_completions/gpt.py", line 113, in chat_completion
    multi_modal_messages = await ResourceProcessor(
                           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "./aidial_adapter_openai/chat_completions/transformation.py", line 187, in transform_messages
    transformations = [
                      ^
  File "./aidial_adapter_openai/chat_completions/transformation.py", line 188, in <listcomp>
    await self.transform_message(message) for message in messages
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./aidial_adapter_openai/chat_completions/transformation.py", line 162, in transform_message
    custom_content = ensure_dict(
                     ^^^^^^^^^^^^
  File "./aidial_adapter_openai/utils/validation.py", line 19, in ensure_dict
    return _ensure_type(name, value, dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./aidial_adapter_openai/utils/validation.py", line 13, in _ensure_type
    raise InvalidRequestError(
aidial_sdk.exceptions.InvalidRequestError: 'custom_content' expected to be dict, but got NoneType
```

</details>

**After**: the adapter processes the request successfully.

> [!NOTE]
> `custom_content` *isn't nullable* in the DIAL API, so the error is justified. However, the validation was missing originally so certain clients have had time to write DIAL Client sending `custom_content=null`, and after the validation was introduced, they received the error.