### PR TITLE
fix: fix overestimation of prompt tokens for chat completion requests

### DIFF
--- a/aidial_adapter_openai/chat_completions/transformation.py
+++ b/aidial_adapter_openai/chat_completions/transformation.py
@@ -10,7 +10,7 @@ from openai.types.chat.chat_completion_assistant_message_param import (
     ContentArrayOfContentPart,
 )
 from openai.types.chat.chat_completion_content_part_param import File
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from aidial_adapter_openai.dial_api.resource import (
     AttachmentResource,
@@ -44,15 +44,22 @@ class Error:
     message: str
 
 
-class ResourceProcessor(BaseModel):
-    class Config:
-        arbitrary_types_allowed = True  # for errors
-
+class MessageTransformer:
     file_storage: FileStorage | None
+    errors: Set[Error]
+    images: List[ImageResource]
+    files: List[FileResource]
 
-    errors: Set[Error] = Field(default_factory=set)
-    images: List[ImageResource] = []
-    files: List[FileResource] = []
+    def __init__(
+        self,
+        *,
+        file_storage: FileStorage | None,
+        errors: Set[Error] | None = None,
+    ):
+        self.file_storage = file_storage
+        self.errors = set() if errors is None else errors
+        self.images = []
+        self.files = []
 
     async def try_download_resource(
         self, dial_resource: DialResource
@@ -181,15 +188,23 @@ class ResourceProcessor(BaseModel):
             },
         )
 
+
+class ResourceProcessor(BaseModel):
+    file_storage: FileStorage | None
+
     async def transform_messages(
         self, messages: List[dict]
     ) -> List[MultiModalMessage]:
+        errors: Set[Error] = set()
         transformations = [
-            await self.transform_message(message) for message in messages
+            await MessageTransformer(
+                file_storage=self.file_storage, errors=errors
+            ).transform_message(message)
+            for message in messages
         ]
 
-        if self.errors:
-            fails = sorted(list(self.errors))
+        if errors:
+            fails = sorted(list(errors))
             msg = "The following files failed to process:\n"
             msg += "\n".join(
                 f"{idx}. {error.name}: {decapitalize(error.message)}"

--- a/aidial_adapter_openai/responses/adapter.py
+++ b/aidial_adapter_openai/responses/adapter.py
@@ -115,7 +115,7 @@ async def chat_completion(
     messages = request["messages"]
 
     transformed_messages = await ResourceProcessor(
-        file_storage=file_storage,
+        file_storage=file_storage
     ).transform_messages(messages)
 
     input_messages = convert_messages(

--- a/aidial_adapter_openai/responses/adapter.py
+++ b/aidial_adapter_openai/responses/adapter.py
@@ -115,7 +115,7 @@ async def chat_completion(
     messages = request["messages"]
 
     transformed_messages = await ResourceProcessor(
-        file_storage=file_storage
+        file_storage=file_storage,
     ).transform_messages(messages)
 
     input_messages = convert_messages(

--- a/tests/unit_tests/test_attachments.py
+++ b/tests/unit_tests/test_attachments.py
@@ -2,7 +2,7 @@ import pytest
 
 from aidial_adapter_openai.chat_completions.transformation import (
     Error,
-    ResourceProcessor,
+    MessageTransformer,
 )
 from aidial_adapter_openai.dial_api.resource import (
     AttachmentResource,
@@ -12,6 +12,11 @@ from aidial_adapter_openai.dial_api.resource import (
 from aidial_adapter_openai.utils.resource.base import Resource
 from tests.utils.images import data_url, pic_1_1
 from tests.utils.storage import DummyFileStorage
+
+
+@pytest.fixture
+def mock_message_transformer():
+    return MessageTransformer(file_storage=DummyFileStorage())
 
 
 @pytest.mark.parametrize(
@@ -130,18 +135,21 @@ async def test_get_attachment_name(attachment, expected_name):
         ),
     ],
 )
-async def test_download_image_url(url: str, expected_result: Resource | Error):
+async def test_download_image_url(
+    mock_message_transformer: MessageTransformer,
+    url: str,
+    expected_result: Resource | Error,
+):
     resource = URLResource(
         url=url,
         entity_name="image",
         supported_types=["image/png"],
     )
-    processor = ResourceProcessor(file_storage=DummyFileStorage())
-    result = await processor.try_download_resource(resource)
+    result = await mock_message_transformer.try_download_resource(resource)
     if isinstance(expected_result, Resource):
         assert result == expected_result
     else:
-        assert processor.errors == {expected_result}
+        assert mock_message_transformer.errors == {expected_result}
 
 
 @pytest.mark.parametrize(
@@ -208,16 +216,17 @@ async def test_download_image_url(url: str, expected_result: Resource | Error):
     ],
 )
 async def test_download_attachment_image(
-    attachment: dict, expected_result: Resource | Error
+    mock_message_transformer: MessageTransformer,
+    attachment: dict,
+    expected_result: Resource | Error,
 ):
     resource = AttachmentResource(
         attachment=parse_attachment(attachment),
         entity_name="image",
         supported_types=["image/png"],
     )
-    processor = ResourceProcessor(file_storage=DummyFileStorage())
-    result = await processor.try_download_resource(resource)
+    result = await mock_message_transformer.try_download_resource(resource)
     if isinstance(expected_result, Resource):
         assert result == expected_result
     else:
-        assert processor.errors == {expected_result}
+        assert mock_message_transformer.errors == {expected_result}

--- a/tests/unit_tests/test_multimodal_transformation.py
+++ b/tests/unit_tests/test_multimodal_transformation.py
@@ -3,6 +3,7 @@ from aidial_sdk.exceptions import HTTPException as DialException
 
 from aidial_adapter_openai.chat_completions.transformation import (
     Error,
+    MessageTransformer,
     ResourceProcessor,
 )
 from aidial_adapter_openai.utils.multi_modal_message import MultiModalMessage
@@ -36,20 +37,9 @@ def mock_resource_processor():
     return ResourceProcessor(file_storage=DummyFileStorage())
 
 
-# @pytest.fixture
-# def mock_image_tokenizer():
-#     def image_tokenizer(*args):
-#         class _Tokenizer:
-#             def tokenize(self, *args):
-#                 return TOKENS_FOR_IMAGE
-
-#         return _Tokenizer()
-
-#     with patch(
-#         "aidial_adapter_openai.endpoints.chat_completion.get_image_tokenizer",
-#         return_value=image_tokenizer,
-#     ):
-#         yield
+@pytest.fixture
+def mock_message_transformer():
+    return MessageTransformer(file_storage=DummyFileStorage())
 
 
 @pytest.mark.parametrize(
@@ -99,11 +89,11 @@ def mock_resource_processor():
     ],
 )
 async def test_transform_to_content_parts(
-    mock_resource_processor: ResourceProcessor,
+    mock_message_transformer: MessageTransformer,
     message,
     expected_content,
 ):
-    result = await mock_resource_processor.transform_message(message)
+    result = await mock_message_transformer.transform_message(message)
 
     assert isinstance(result, MultiModalMessage)
     assert result.raw_message.get("custom_content") is None
@@ -140,17 +130,17 @@ The following files failed to process:
 
 
 async def test_transform_message_not_found(
-    mock_resource_processor: ResourceProcessor,
+    mock_message_transformer: MessageTransformer,
 ):
     message = {
         "role": "user",
         "content": "",
         "custom_content": {"attachments": [{"url": "not_found.jpg"}]},
     }
-    await mock_resource_processor.transform_message(message)
-    assert mock_resource_processor.errors
-    assert len(mock_resource_processor.errors) == 1
-    image_fail = list(mock_resource_processor.errors)[0]
+    await mock_message_transformer.transform_message(message)
+    assert mock_message_transformer.errors is not None
+    assert len(mock_message_transformer.errors) == 1
+    image_fail = list(mock_message_transformer.errors)[0]
     assert isinstance(image_fail, Error)
     assert image_fail.name == "not_found.jpg"
     assert image_fail.message == "File not found"

--- a/tests/unit_tests/test_multimodal_transformation.py
+++ b/tests/unit_tests/test_multimodal_transformation.py
@@ -8,9 +8,13 @@ from aidial_adapter_openai.chat_completions.transformation import (
 )
 from aidial_adapter_openai.utils.multi_modal_message import MultiModalMessage
 from aidial_adapter_openai.utils.resource.base import Resource
+from aidial_adapter_openai.utils.resource.file import FileResource
 from aidial_adapter_openai.utils.resource.image import ImageResource
 from tests.utils.images import data_url, pic_1_1, pic_2_2, pic_3_3
 from tests.utils.storage import DummyFileStorage
+
+_file_1 = Resource(type="application/pdf", data=b"document content 1")
+_file_2 = Resource(type="application/pdf", data=b"document content 2")
 
 
 def attachment(resource: Resource) -> dict:
@@ -21,10 +25,24 @@ def image_metadata(resource: Resource, w: int, h: int) -> ImageResource:
     return ImageResource(width=w, height=h, detail="low", image=resource)
 
 
+def file_resource(resource: Resource) -> FileResource:
+    return FileResource(name="data attachment", resource=resource)
+
+
 def image_url(resource: Resource) -> dict:
     return {
         "type": "image_url",
         "image_url": {"url": data_url(resource), "detail": "low"},
+    }
+
+
+def file_part(resource: Resource) -> dict:
+    return {
+        "type": "file",
+        "file": {
+            "filename": "data attachment",
+            "file_data": resource.to_data_url(),
+        },
     }
 
 
@@ -67,6 +85,15 @@ def mock_message_transformer():
                 text(""),
                 image_url(pic_1_1),
             ],
+        ),
+        # Message with one file
+        (
+            {
+                "role": "user",
+                "content": "",
+                "custom_content": {"attachments": [attachment(_file_1)]},
+            },
+            [text(""), file_part(_file_1)],
         ),
         # Message with multiple images
         (
@@ -272,7 +299,7 @@ async def test_transform_message_not_found(
                 )
             ],
         ),
-        # Image in multiple messages
+        # Image and files in multiple messages
         (
             [
                 {
@@ -280,6 +307,7 @@ async def test_transform_message_not_found(
                     "content": "hello",
                     "custom_content": {
                         "attachments": [
+                            attachment(_file_1),
                             attachment(pic_1_1),
                         ]
                     },
@@ -290,6 +318,7 @@ async def test_transform_message_not_found(
                     "custom_content": {
                         "attachments": [
                             attachment(pic_2_2),
+                            attachment(_file_2),
                             attachment(pic_3_3),
                         ]
                     },
@@ -300,10 +329,12 @@ async def test_transform_message_not_found(
                     images=[
                         image_metadata(pic_1_1, 1, 1),
                     ],
+                    files=[file_resource(_file_1)],
                     raw_message={
                         "role": "user",
                         "content": [
                             text("hello"),
+                            file_part(_file_1),
                             image_url(pic_1_1),
                         ],
                     },
@@ -313,11 +344,13 @@ async def test_transform_message_not_found(
                         image_metadata(pic_2_2, 2, 2),
                         image_metadata(pic_3_3, 3, 3),
                     ],
+                    files=[file_resource(_file_2)],
                     raw_message={
                         "role": "user",
                         "content": [
                             text("world"),
                             image_url(pic_2_2),
+                            file_part(_file_2),
                             image_url(pic_3_3),
                         ],
                     },

--- a/tests/unit_tests/test_multimodal_transformation.py
+++ b/tests/unit_tests/test_multimodal_transformation.py
@@ -21,7 +21,7 @@ def attachment(resource: Resource) -> dict:
     return {"type": resource.type, "data": resource.data_base64}
 
 
-def image_metadata(resource: Resource, w: int, h: int) -> ImageResource:
+def image_resource(resource: Resource, w: int, h: int) -> ImageResource:
     return ImageResource(width=w, height=h, detail="low", image=resource)
 
 
@@ -29,7 +29,7 @@ def file_resource(resource: Resource) -> FileResource:
     return FileResource(name="data attachment", resource=resource)
 
 
-def image_url(resource: Resource) -> dict:
+def image_part(resource: Resource) -> dict:
     return {
         "type": "image_url",
         "image_url": {"url": data_url(resource), "detail": "low"},
@@ -46,7 +46,7 @@ def file_part(resource: Resource) -> dict:
     }
 
 
-def text(text: str) -> dict:
+def text_part(text: str) -> dict:
     return {"type": "text", "text": text}
 
 
@@ -82,8 +82,8 @@ def mock_message_transformer():
                 "custom_content": {"attachments": [attachment(pic_1_1)]},
             },
             [
-                text(""),
-                image_url(pic_1_1),
+                text_part(""),
+                image_part(pic_1_1),
             ],
         ),
         # Message with one file
@@ -93,7 +93,7 @@ def mock_message_transformer():
                 "content": "",
                 "custom_content": {"attachments": [attachment(_file_1)]},
             },
-            [text(""), file_part(_file_1)],
+            [text_part(""), file_part(_file_1)],
         ),
         # Message with multiple images
         (
@@ -108,9 +108,9 @@ def mock_message_transformer():
                 },
             },
             [
-                text("test with multiple images"),
-                image_url(pic_1_1),
-                image_url(pic_2_2),
+                text_part("test with multiple images"),
+                image_part(pic_1_1),
+                image_part(pic_2_2),
             ],
         ),
     ],
@@ -198,10 +198,10 @@ async def test_transform_message_not_found(
                     raw_message={"role": "system", "content": "Hello"},
                 ),
                 MultiModalMessage(
-                    images=[image_metadata(pic_1_1, 1, 1)],
+                    images=[image_resource(pic_1_1, 1, 1)],
                     raw_message={
                         "role": "user",
-                        "content": [text(""), image_url(pic_1_1)],
+                        "content": [text_part(""), image_part(pic_1_1)],
                     },
                 ),
             ],
@@ -245,19 +245,19 @@ async def test_transform_message_not_found(
                 {
                     "role": "user",
                     "content": [
-                        text("User"),
-                        image_url(pic_1_1),
+                        text_part("User"),
+                        image_part(pic_1_1),
                     ],
                 },
             ],
             [
                 MultiModalMessage(
-                    images=[image_metadata(pic_1_1, 1, 1)],
+                    images=[image_resource(pic_1_1, 1, 1)],
                     raw_message={
                         "role": "user",
                         "content": [
-                            text("User"),
-                            image_url(pic_1_1),
+                            text_part("User"),
+                            image_part(pic_1_1),
                         ],
                     },
                 )
@@ -269,8 +269,8 @@ async def test_transform_message_not_found(
                 {
                     "role": "user",
                     "content": [
-                        image_url(pic_1_1),
-                        text("User"),
+                        image_part(pic_1_1),
+                        text_part("User"),
                     ],
                     "custom_content": {
                         "attachments": [
@@ -283,17 +283,17 @@ async def test_transform_message_not_found(
             [
                 MultiModalMessage(
                     images=[
-                        image_metadata(pic_1_1, 1, 1),
-                        image_metadata(pic_2_2, 2, 2),
-                        image_metadata(pic_3_3, 3, 3),
+                        image_resource(pic_1_1, 1, 1),
+                        image_resource(pic_2_2, 2, 2),
+                        image_resource(pic_3_3, 3, 3),
                     ],
                     raw_message={
                         "role": "user",
                         "content": [
-                            image_url(pic_1_1),
-                            text("User"),
-                            image_url(pic_2_2),
-                            image_url(pic_3_3),
+                            image_part(pic_1_1),
+                            text_part("User"),
+                            image_part(pic_2_2),
+                            image_part(pic_3_3),
                         ],
                     },
                 )
@@ -327,31 +327,31 @@ async def test_transform_message_not_found(
             [
                 MultiModalMessage(
                     images=[
-                        image_metadata(pic_1_1, 1, 1),
+                        image_resource(pic_1_1, 1, 1),
                     ],
                     files=[file_resource(_file_1)],
                     raw_message={
                         "role": "user",
                         "content": [
-                            text("hello"),
+                            text_part("hello"),
                             file_part(_file_1),
-                            image_url(pic_1_1),
+                            image_part(pic_1_1),
                         ],
                     },
                 ),
                 MultiModalMessage(
                     images=[
-                        image_metadata(pic_2_2, 2, 2),
-                        image_metadata(pic_3_3, 3, 3),
+                        image_resource(pic_2_2, 2, 2),
+                        image_resource(pic_3_3, 3, 3),
                     ],
                     files=[file_resource(_file_2)],
                     raw_message={
                         "role": "user",
                         "content": [
-                            text("world"),
-                            image_url(pic_2_2),
+                            text_part("world"),
+                            image_part(pic_2_2),
                             file_part(_file_2),
-                            image_url(pic_3_3),
+                            image_part(pic_3_3),
                         ],
                     },
                 ),

--- a/tests/unit_tests/test_multimodal_transformation.py
+++ b/tests/unit_tests/test_multimodal_transformation.py
@@ -11,9 +11,6 @@ from aidial_adapter_openai.utils.resource.image import ImageResource
 from tests.utils.images import data_url, pic_1_1, pic_2_2, pic_3_3
 from tests.utils.storage import DummyFileStorage
 
-TOKENS_FOR_TEXT = 10
-TOKENS_FOR_IMAGE = 20
-
 
 def attachment(resource: Resource) -> dict:
     return {"type": resource.type, "data": resource.data_base64}
@@ -39,11 +36,27 @@ def mock_resource_processor():
     return ResourceProcessor(file_storage=DummyFileStorage())
 
 
+# @pytest.fixture
+# def mock_image_tokenizer():
+#     def image_tokenizer(*args):
+#         class _Tokenizer:
+#             def tokenize(self, *args):
+#                 return TOKENS_FOR_IMAGE
+
+#         return _Tokenizer()
+
+#     with patch(
+#         "aidial_adapter_openai.endpoints.chat_completion.get_image_tokenizer",
+#         return_value=image_tokenizer,
+#     ):
+#         yield
+
+
 @pytest.mark.parametrize(
-    "message,expected_tokens,expected_content",
+    "message,expected_content",
     [
         # Message without attachments
-        ({"role": "user", "content": "Hello"}, TOKENS_FOR_TEXT, "Hello"),
+        ({"role": "user", "content": "Hello"}, "Hello"),
         # Message with empty attachments
         (
             {
@@ -51,7 +64,6 @@ def mock_resource_processor():
                 "content": "Hi",
                 "custom_content": {"attachments": []},
             },
-            TOKENS_FOR_TEXT,
             "Hi",
         ),
         # Message with one image
@@ -61,7 +73,6 @@ def mock_resource_processor():
                 "content": "",
                 "custom_content": {"attachments": [attachment(pic_1_1)]},
             },
-            TOKENS_FOR_TEXT + TOKENS_FOR_IMAGE,
             [
                 text(""),
                 image_url(pic_1_1),
@@ -79,7 +90,6 @@ def mock_resource_processor():
                     ]
                 },
             },
-            TOKENS_FOR_TEXT + 2 * TOKENS_FOR_IMAGE,
             [
                 text("test with multiple images"),
                 image_url(pic_1_1),
@@ -88,10 +98,9 @@ def mock_resource_processor():
         ),
     ],
 )
-async def test_transform_message(
+async def test_transform_to_content_parts(
     mock_resource_processor: ResourceProcessor,
     message,
-    expected_tokens,
     expected_content,
 ):
     result = await mock_resource_processor.transform_message(message)
@@ -101,7 +110,7 @@ async def test_transform_message(
     assert result.raw_message["content"] == expected_content
 
 
-async def test_transform_messages_with_error(
+async def test_transform_messages_not_found(
     mock_resource_processor: ResourceProcessor,
 ):
     messages = [
@@ -130,7 +139,7 @@ The following files failed to process:
     )
 
 
-async def test_transform_message_with_error(
+async def test_transform_message_not_found(
     mock_resource_processor: ResourceProcessor,
 ):
     message = {
@@ -273,9 +282,61 @@ async def test_transform_message_with_error(
                 )
             ],
         ),
+        # Image in multiple messages
+        (
+            [
+                {
+                    "role": "user",
+                    "content": "hello",
+                    "custom_content": {
+                        "attachments": [
+                            attachment(pic_1_1),
+                        ]
+                    },
+                },
+                {
+                    "role": "user",
+                    "content": "world",
+                    "custom_content": {
+                        "attachments": [
+                            attachment(pic_2_2),
+                            attachment(pic_3_3),
+                        ]
+                    },
+                },
+            ],
+            [
+                MultiModalMessage(
+                    images=[
+                        image_metadata(pic_1_1, 1, 1),
+                    ],
+                    raw_message={
+                        "role": "user",
+                        "content": [
+                            text("hello"),
+                            image_url(pic_1_1),
+                        ],
+                    },
+                ),
+                MultiModalMessage(
+                    images=[
+                        image_metadata(pic_2_2, 2, 2),
+                        image_metadata(pic_3_3, 3, 3),
+                    ],
+                    raw_message={
+                        "role": "user",
+                        "content": [
+                            text("world"),
+                            image_url(pic_2_2),
+                            image_url(pic_3_3),
+                        ],
+                    },
+                ),
+            ],
+        ),
     ],
 )
-async def test_transform_messages(
+async def test_transform_to_unified_messages(
     mock_resource_processor: ResourceProcessor,
     messages,
     expected_transformations,


### PR DESCRIPTION
The PR fixes the bug introduced in https://github.com/epam/ai-dial-adapter-openai/pull/276 in the [release 0.32.0](https://github.com/epam/ai-dial-adapter-openai/releases/tag/0.32.0).

The bug manifests itself in the overestimation of prompt tokens computed by the adapter for chat completion responses.

The overestimation occurs under the following conditions:
1. The requested deployment is registered in either `GPT4O_DEPLOYMENTS` or `GPT4O_MINI_DEPLOYMENTS` variables.
2. The upstream didn't return prompt tokens _(it typically happens when `stream=True` and `include_usage` option isn't provided)_.
3. The request contains an image in a message other than the last one.

When these conditions are met, the adapter incorrectly computes the sum of image tokens over request messages.
So instead of the correct sum:

$$
\sum_{i=0}^{n-1} \text{imageTokens}(\text{message}[i]),
$$

the adapter computes the cumulative sums: 

$$
\sum_{i=0}^{n-1} (n - i) * \text{imageTokens}(\text{message}[i])
$$

This leads to token overestimation that, in the worst-case scenario, is proportional to the number of request messages $n$.
