### PR TITLE
fix: return 502 on an invalid upstream endpoint

### DIFF
--- a/aidial_adapter_openai/utils/parsers.py
+++ b/aidial_adapter_openai/utils/parsers.py
@@ -2,7 +2,7 @@ import re
 from json import JSONDecodeError
 from typing import Any, Dict, TypedDict
 
-from aidial_sdk.exceptions import InvalidRequestError
+from aidial_sdk.exceptions import InternalServerError, InvalidRequestError
 from fastapi import Request
 from openai import AsyncAzureOpenAI, AsyncOpenAI, Timeout
 
@@ -92,7 +92,7 @@ class EndpointParser(ExtraForbidModel):
     def parse(self, endpoint: str) -> AzureOpenAIEndpoint | OpenAIEndpoint:
         if result := self.try_parse(endpoint):
             return result
-        raise InvalidRequestError("Invalid upstream endpoint format")
+        raise InternalServerError("Invalid upstream endpoint format")
 
 
 class CompletionsParser(ExtraForbidModel):

--- a/aidial_adapter_openai/utils/parsers.py
+++ b/aidial_adapter_openai/utils/parsers.py
@@ -1,8 +1,9 @@
 import re
+from http import HTTPStatus
 from json import JSONDecodeError
 from typing import Any, Dict, TypedDict
 
-from aidial_sdk.exceptions import InternalServerError, InvalidRequestError
+from aidial_sdk.exceptions import HTTPException, InvalidRequestError
 from fastapi import Request
 from openai import AsyncAzureOpenAI, AsyncOpenAI, Timeout
 
@@ -92,7 +93,11 @@ class EndpointParser(ExtraForbidModel):
     def parse(self, endpoint: str) -> AzureOpenAIEndpoint | OpenAIEndpoint:
         if result := self.try_parse(endpoint):
             return result
-        raise InternalServerError("Invalid upstream endpoint format")
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_GATEWAY,
+            type="internal_server_error",
+            message="Invalid upstream endpoint format",
+        )
 
 
 class CompletionsParser(ExtraForbidModel):

--- a/tests/unit_tests/test_app_config.py
+++ b/tests/unit_tests/test_app_config.py
@@ -1,5 +1,5 @@
 import pytest
-from aidial_sdk.exceptions import InternalServerError
+from aidial_sdk.exceptions import HTTPException
 
 from aidial_adapter_openai.configuration.app_config import ApplicationConfig
 from aidial_adapter_openai.configuration.deployment_type import (
@@ -114,7 +114,7 @@ def test_app_config_chat_completions_azure_next_gen(
 
 
 def test_app_config_chat_invalid(origin: str, deployment: str):
-    with pytest.raises(InternalServerError) as exc_info:
+    with pytest.raises(HTTPException) as exc_info:
         (
             ApplicationConfig()
             .add_deployment(deployment, D.GPT4O)
@@ -124,6 +124,9 @@ def test_app_config_chat_invalid(origin: str, deployment: str):
         )
 
     error = exc_info.value
+    assert error.status_code == 502
+    assert error.code == "502"
+    assert error.type == "internal_server_error"
     assert error.message == "Invalid upstream endpoint format"
 
 

--- a/tests/unit_tests/test_app_config.py
+++ b/tests/unit_tests/test_app_config.py
@@ -1,5 +1,5 @@
 import pytest
-from aidial_sdk.exceptions import InvalidRequestError
+from aidial_sdk.exceptions import InternalServerError
 
 from aidial_adapter_openai.configuration.app_config import ApplicationConfig
 from aidial_adapter_openai.configuration.deployment_type import (
@@ -114,7 +114,7 @@ def test_app_config_chat_completions_azure_next_gen(
 
 
 def test_app_config_chat_invalid(origin: str, deployment: str):
-    with pytest.raises(InvalidRequestError) as exc_info:
+    with pytest.raises(InternalServerError) as exc_info:
         (
             ApplicationConfig()
             .add_deployment(deployment, D.GPT4O)

--- a/tests/unit_tests/test_errors.py
+++ b/tests/unit_tests/test_errors.py
@@ -465,12 +465,12 @@ async def test_incorrect_upstream_url(test_app: httpx.AsyncClient):
         },
     )
 
-    assert response.status_code == 500
+    assert response.status_code == 502
     assert response.json() == {
         "error": {
             "message": "Invalid upstream endpoint format",
             "type": "internal_server_error",
-            "code": "500",
+            "code": "502",
         }
     }
 

--- a/tests/unit_tests/test_errors.py
+++ b/tests/unit_tests/test_errors.py
@@ -465,12 +465,12 @@ async def test_incorrect_upstream_url(test_app: httpx.AsyncClient):
         },
     )
 
-    assert response.status_code == 400
+    assert response.status_code == 500
     assert response.json() == {
         "error": {
             "message": "Invalid upstream endpoint format",
-            "type": "invalid_request_error",
-            "code": "400",
+            "type": "internal_server_error",
+            "code": "500",
         }
     }
 


### PR DESCRIPTION
Imagine the incorrectly configured upstream in the DIAL Core config:

```json
{
    "models": {
        "gpt-4": {
            "upstreams": [
                {
                    "endpoint": "http://example.com/hello/world"
                },
                {
                    "endpoint": "http://azure-openai-service.com/openai/deployments/gpt-4/chat/completions"
                }
            ]
        }
    }
}
```

1. DIAL Client calls `gpt-4` deployment in DIAL Core 
2. DIAL Core sends the chat completion request to OpenAI adapter with `X-UPSTREAM-ENDPOINT:http://example.com/hello/world`
3. The adapter returns `400 Invalid upstream endpoint format`
4. DIAL Core returns `400 Invalid upstream endpoint format` to the DIAL client

This is bad, since there is a perfectly valid second endpoint, which DIAL Core should have tried before giving up.
To achieve this, we only need to change the status code of the error returned by the Adapter in case of the invalid upstream:

1. DIAL Client calls `gpt-4` deployment in DIAL Core 
2. DIAL Core sends the chat completion request to OpenAI adapter with `X-UPSTREAM-ENDPOINT:http://example.com/hello/world`
3. The adapter returns `502 Invalid upstream endpoint format`
4. DIAL Core sees `502 Invalid upstream endpoint format` and tries again with another endpoint (valid this time)
5. DIAL Core sends the chat completion request to OpenAI adapter with `X-UPSTREAM-ENDPOINT:http://azure-openai-service.com/openai/deployments/gpt-4/chat/completions`
6. Adapter returns 200
7. DIAL Core returns 200 to the client

502 makes sense, since the upstream is indeed unreachable and therefore bad.