### PR TITLE
fix: remove `stream_options` for non-streaming chat completion requests

### DIFF
--- a/aidial_adapter_openai/endpoints/chat_completion.py
+++ b/aidial_adapter_openai/endpoints/chat_completion.py
@@ -200,10 +200,10 @@ async def chat_completion(deployment_id: str, request: Request):
     if emulate_streaming:
         request_body["stream"] = False
 
-    api_version = get_api_version(request)
-
     if not is_stream and request_body.get("stream_options") is not None:
         request_body.pop("stream_options")
+
+    api_version = get_api_version(request)
 
     return await create_server_response(
         emulate_streaming,

--- a/aidial_adapter_openai/endpoints/chat_completion.py
+++ b/aidial_adapter_openai/endpoints/chat_completion.py
@@ -202,6 +202,9 @@ async def chat_completion(deployment_id: str, request: Request):
 
     api_version = get_api_version(request)
 
+    if not is_stream and request_body.get("stream_options") is not None:
+        request_body.pop("stream_options")
+
     return await create_server_response(
         emulate_streaming,
         await call_chat_completion(

--- a/tests/unit_tests/test_preprocessing.py
+++ b/tests/unit_tests/test_preprocessing.py
@@ -6,6 +6,11 @@ import respx
 
 from tests.utils.stream import OpenAIStream, single_choice_chunk
 
+_API_VERSION = "api-version=2023-03-15-preview"
+_UPSTREAM_ENDPOINT = (
+    "http://localhost:5001/openai/deployments/gpt-4/chat/completions"
+)
+
 
 @respx.mock
 @pytest.mark.parametrize("stream", [True, False], ids=["stream", "block"])
@@ -39,12 +44,12 @@ async def test_stream_options(test_app: httpx.AsyncClient, stream: bool):
                 json=chat_completion_response.to_block_response(),
             )
 
-    respx.post(
-        "http://localhost:5001/openai/deployments/gpt-4/chat/completions?api-version=2023-03-15-preview"
-    ).mock(side_effect=chat_completion_handler)
+    respx.post(f"{_UPSTREAM_ENDPOINT}?{_API_VERSION}").mock(
+        side_effect=chat_completion_handler
+    )
 
     response = await test_app.post(
-        "/openai/deployments/gpt-4/chat/completions?api-version=2023-03-15-preview",
+        f"/openai/deployments/gpt-4/chat/completions?{_API_VERSION}",
         json={
             "messages": [{"role": "user", "content": "Test content"}],
             "stream": stream,
@@ -52,7 +57,7 @@ async def test_stream_options(test_app: httpx.AsyncClient, stream: bool):
         },
         headers={
             "X-UPSTREAM-KEY": "TEST_API_KEY",
-            "X-UPSTREAM-ENDPOINT": "http://localhost:5001/openai/deployments/gpt-4/chat/completions",
+            "X-UPSTREAM-ENDPOINT": _UPSTREAM_ENDPOINT,
         },
     )
 

--- a/tests/unit_tests/test_preprocessing.py
+++ b/tests/unit_tests/test_preprocessing.py
@@ -1,0 +1,59 @@
+import json
+
+import httpx
+import pytest
+import respx
+
+from tests.utils.stream import OpenAIStream, single_choice_chunk
+
+
+@respx.mock
+@pytest.mark.parametrize("stream", [True, False], ids=["stream", "block"])
+async def test_stream_options(test_app: httpx.AsyncClient, stream: bool):
+    chat_completion_response = OpenAIStream(
+        single_choice_chunk(
+            finish_reason="stop", delta={"role": "assistant", "content": "test"}
+        ),
+    )
+
+    def chat_completion_handler(request: httpx.Request):
+        body = json.loads(request.content)
+        stream = body.get("stream", False)
+        stream_options = "stream_options" in body
+
+        if stream:
+            assert (
+                stream_options
+            ), "stream_options should be preserved for streaming requests"
+            return httpx.Response(
+                status_code=200,
+                headers={"Content-Type": "text/event-stream"},
+                content=chat_completion_response.to_content(),
+            )
+        else:
+            assert (
+                not stream_options
+            ), "stream_options should be removed for non-streaming requests"
+            return httpx.Response(
+                status_code=200,
+                json=chat_completion_response.to_block_response(),
+            )
+
+    respx.post(
+        "http://localhost:5001/openai/deployments/gpt-4/chat/completions?api-version=2023-03-15-preview"
+    ).mock(side_effect=chat_completion_handler)
+
+    response = await test_app.post(
+        "/openai/deployments/gpt-4/chat/completions?api-version=2023-03-15-preview",
+        json={
+            "messages": [{"role": "user", "content": "Test content"}],
+            "stream": stream,
+            "stream_options": {"include_usage": True},
+        },
+        headers={
+            "X-UPSTREAM-KEY": "TEST_API_KEY",
+            "X-UPSTREAM-ENDPOINT": "http://localhost:5001/openai/deployments/gpt-4/chat/completions",
+        },
+    )
+
+    assert response.status_code == 200


### PR DESCRIPTION
The following chat completion request:

```json
{
  "stream": false,
  "stream_options": {
    "include_usage": true
  },
  "messages": [
    {
      "role": "user",
      "content": "test"
    }
  ]
}
```

leads to the following error coming from Azure:

```json
{
  "error": {
    "message": "The 'stream_options' parameter is only allowed when 'stream' is enabled.",
    "type": "invalid_request_error",
    "param": "stream_options",
    "code": null
  }
}
```

This precludes presetting of `"include_usage": true` in the DIAL Core config via `defaults` since all non-streaming requests are going to fail with the error.

The easy and safe workaround for it - is to remove `stream_options` from the request when `stream=false`.