### PR TITLE
fix: return 502 for errors caused by particular upstream configuration

### DIFF
--- a/aidial_adapter_openai/exception_handlers.py
+++ b/aidial_adapter_openai/exception_handlers.py
@@ -22,6 +22,14 @@ def to_adapter_exception(exc: Exception) -> AdapterException:
     return _expose_error_message_to_user(_convert_to_adapter_exception(exc))
 
 
+def _get_status_code(exc: APIStatusError) -> int:
+    has_api_key_header = "api-key" in exc.request.headers
+    code = exc.status_code
+    if code == 500 or (code in (401, 403) and has_api_key_header):
+        code = 502
+    return code
+
+
 def _convert_to_adapter_exception(exc: Exception) -> AdapterException:
 
     if isinstance(exc, (DialException, ResponseWrapper)):
@@ -50,9 +58,7 @@ def _convert_to_adapter_exception(exc: Exception) -> AdapterException:
         if "Content-Encoding" in httpx_headers:
             del httpx_headers["Content-Encoding"]
 
-        status_code = r.status_code
-        if status_code in (500, 401, 403):
-            status_code = 502
+        status_code = _get_status_code(exc)
 
         return parse_adapter_exception(
             status_code=status_code,

--- a/aidial_adapter_openai/exception_handlers.py
+++ b/aidial_adapter_openai/exception_handlers.py
@@ -50,8 +50,12 @@ def _convert_to_adapter_exception(exc: Exception) -> AdapterException:
         if "Content-Encoding" in httpx_headers:
             del httpx_headers["Content-Encoding"]
 
+        status_code = r.status_code
+        if status_code in (500, 401, 403):
+            status_code = 502
+
         return parse_adapter_exception(
-            status_code=r.status_code,
+            status_code=status_code,
             headers=httpx_headers,
             content=r.text,
         )

--- a/tests/integration_tests/constants.py
+++ b/tests/integration_tests/constants.py
@@ -44,7 +44,7 @@ try:
     TEST_DEPLOYMENTS_CONFIG = TestDeployments.from_config(
         TEST_DEPLOYMENTS_CONFIG_PATH
     )
-except FileNotFoundError:
+except Exception:
     _log.warning(
         f"Cannot find the configuration file: {TEST_DEPLOYMENTS_CONFIG_PATH}. "
         "Using noop configuration."

--- a/tests/integration_tests/constants.py
+++ b/tests/integration_tests/constants.py
@@ -44,7 +44,7 @@ try:
     TEST_DEPLOYMENTS_CONFIG = TestDeployments.from_config(
         TEST_DEPLOYMENTS_CONFIG_PATH
     )
-except Exception:
+except FileNotFoundError:
     _log.warning(
         f"Cannot find the configuration file: {TEST_DEPLOYMENTS_CONFIG_PATH}. "
         "Using noop configuration."

--- a/tests/unit_tests/test_errors.py
+++ b/tests/unit_tests/test_errors.py
@@ -32,6 +32,11 @@ from tests.utils.stream import (
     single_choice_chunk,
 )
 
+_API_VERSION = "api-version=2023-03-15-preview"
+_UPSTREAM_ENDPOINT = (
+    "http://localhost:5001/openai/deployments/gpt-4/chat/completions"
+)
+
 
 def assert_equal(actual: Any, expected: Any):
     assert actual == expected
@@ -1044,7 +1049,7 @@ async def test_error_from_gpt_multi_modal(stream: bool):
             },
         )
 
-        assert response.status_code == 500
+        assert response.status_code == 502
         assert response.content == b"Something went wrong"
 
 
@@ -1276,3 +1281,63 @@ async def test_rate_limit_exceeded_during_streaming():
                 "type": "server_error",
             }
         }
+
+
+@respx.mock
+@pytest.mark.parametrize("upstream_error_code", [400, 401, 403, 500, 502, 503])
+@pytest.mark.parametrize("error_during_streaming", [True, False])
+@pytest.mark.parametrize("stream", [True, False])
+async def test_upstream_internal_errors_to_502(
+    test_app: httpx.AsyncClient,
+    upstream_error_code: int,
+    error_during_streaming: bool,
+    stream: bool,
+):
+    mock_stream = OpenAIStream(
+        single_choice_chunk(delta={"role": "assistant", "content": "test"}),
+        {
+            "error": {
+                "message": "Upstream streaming error",
+                "code": int(upstream_error_code),
+            }
+        },
+    )
+
+    def chat_completion_handler(request: httpx.Request):
+        streaming = json.loads(request.content).get("stream", False)
+        if streaming and error_during_streaming:
+            return httpx.Response(
+                status_code=200,
+                headers={"Content-Type": "text/event-stream"},
+                content=mock_stream.to_content(),
+            )
+        else:
+            return httpx.Response(
+                status_code=upstream_error_code,
+                content=b"Upstream error",
+            )
+
+    respx.post(f"{_UPSTREAM_ENDPOINT}?{_API_VERSION}").mock(
+        side_effect=chat_completion_handler
+    )
+
+    response = await test_app.post(
+        f"/openai/deployments/gpt-4/chat/completions?{_API_VERSION}",
+        json={
+            "messages": [{"role": "user", "content": "test"}],
+            "stream": stream,
+        },
+        headers={
+            "X-UPSTREAM-KEY": "TEST_API_KEY",
+            "X-UPSTREAM-ENDPOINT": _UPSTREAM_ENDPOINT,
+        },
+    )
+
+    if upstream_error_code in (500, 401, 403) and (
+        not stream or not error_during_streaming
+    ):
+        assert response.status_code == 502
+    elif stream and error_during_streaming:
+        assert response.status_code == 200
+    else:
+        assert response.status_code == upstream_error_code

--- a/tests/unit_tests/test_errors.py
+++ b/tests/unit_tests/test_errors.py
@@ -1285,12 +1285,20 @@ async def test_rate_limit_exceeded_during_streaming():
 
 @respx.mock
 @pytest.mark.parametrize("upstream_error_code", [400, 401, 403, 500, 502, 503])
-@pytest.mark.parametrize("error_during_streaming", [True, False])
-@pytest.mark.parametrize("stream", [True, False])
-async def test_upstream_internal_errors_to_502(
+@pytest.mark.parametrize(
+    "error_during_streaming",
+    [True, False],
+    ids=["error-in-stream", "error-before-stream"],
+)
+@pytest.mark.parametrize(
+    "with_api_key", [True, False], ids=["with-key", "no-key"]
+)
+@pytest.mark.parametrize("stream", [True, False], ids=["stream", "block"])
+async def test_upstream_errors_to_adapter_errors(
     test_app: httpx.AsyncClient,
     upstream_error_code: int,
     error_during_streaming: bool,
+    with_api_key: bool,
     stream: bool,
 ):
     mock_stream = OpenAIStream(
@@ -1314,12 +1322,16 @@ async def test_upstream_internal_errors_to_502(
         else:
             return httpx.Response(
                 status_code=upstream_error_code,
-                content=b"Upstream error",
+                content="Upstream error",
             )
 
     respx.post(f"{_UPSTREAM_ENDPOINT}?{_API_VERSION}").mock(
         side_effect=chat_completion_handler
     )
+
+    headers = {"X-UPSTREAM-ENDPOINT": _UPSTREAM_ENDPOINT}
+    if with_api_key:
+        headers["X-UPSTREAM-KEY"] = "TEST_API_KEY"
 
     response = await test_app.post(
         f"/openai/deployments/gpt-4/chat/completions?{_API_VERSION}",
@@ -1327,17 +1339,16 @@ async def test_upstream_internal_errors_to_502(
             "messages": [{"role": "user", "content": "test"}],
             "stream": stream,
         },
-        headers={
-            "X-UPSTREAM-KEY": "TEST_API_KEY",
-            "X-UPSTREAM-ENDPOINT": _UPSTREAM_ENDPOINT,
-        },
+        headers=headers,
     )
 
-    if upstream_error_code in (500, 401, 403) and (
-        not stream or not error_during_streaming
+    if stream and error_during_streaming:
+        assert response.status_code == 200
+        return
+
+    if upstream_error_code == 500 or (
+        upstream_error_code in (401, 403) and with_api_key
     ):
         assert response.status_code == 502
-    elif stream and error_during_streaming:
-        assert response.status_code == 200
     else:
         assert response.status_code == upstream_error_code

--- a/tests/unit_tests/test_errors.py
+++ b/tests/unit_tests/test_errors.py
@@ -38,6 +38,15 @@ _UPSTREAM_ENDPOINT = (
 )
 
 
+@pytest.fixture(autouse=True)
+def mock_azure_ad_token():
+    with patch(
+        "aidial_adapter_openai.utils.auth.get_api_key",
+        return_value="test-azure-ad-token",
+    ):
+        yield
+
+
 def assert_equal(actual: Any, expected: Any):
     assert actual == expected
 


### PR DESCRIPTION
Logical follow-up of https://github.com/epam/ai-dial-adapter-openai/pull/378

DIAL Core upstream is identified by its `endpoint` and an optional `key`.
This information is passed to the adapter in request headers `X-UPSTREAM-ENDPOINT` and `X-UPSTREAM-KEY`.

Whenever the adapter encounters an upstream endpoint error **linked** to the endpoint identity _(those upstream-specific headers)_, it should return 502 to signal to DIAL Core to try another endpoint.

Status code translation examples

| Status code from upstream                    | Status code from adapter | Comment                                                                                                         |
| -------------------------------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------- |
| 400                                          | 400                      | Since an invalid request is very likely to trigger the same 400 error, retries with other upstreams won't help. |
| 500                                          | 502                      | The upstream encountered an internal error specific to that upstream; retries may help.                         |
| 401/403 (`X-UPSTREAM-KEY` header present) | 502                      | The upstream key was likely misconfigured, so it makes sense to try another upstream.                           |
| 401/403 (`X-UPSTREAM-KEY` header missing) | 401/403                  | The adapter tries to authenticate via Azure AD and fails. Retries won't help.                                   |
