### PR TITLE
feat: support HEADERS_TO_PROXY env var

### DIFF
--- a/aidial_adapter_openai/configuration/app_config.py
+++ b/aidial_adapter_openai/configuration/app_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import Dict, List, assert_never
+from typing import Dict, List, Mapping, assert_never
 
 from aidial_sdk.exceptions import InternalServerError
 
@@ -60,6 +60,8 @@ class ApplicationConfig(ExtraForbidModel):
     ELIMINATE_EMPTY_CHOICES: bool = False
 
     AUDIO_AZURE_API_VERSION: str = "2025-03-01-preview"
+
+    HEADERS_TO_PROXY: List[str] = []
 
     def get_chat_completion_deployment_type(
         self, deployment_id: str, upstream_endpoint: str
@@ -155,6 +157,15 @@ class ApplicationConfig(ExtraForbidModel):
             endpoint=chat_completions_parser.parse(upstream_endpoint),
         )
 
+    def get_headers_to_proxy(
+        self, headers: Mapping[str, str]
+    ) -> dict[str, str]:
+        ret = {}
+        for header in self.HEADERS_TO_PROXY:
+            if (value := headers.get(header)) is not None:
+                ret[header] = value
+        return ret
+
     def add_deployment(
         self, deployment_id: str, deployment_type: D
     ) -> ApplicationConfig:
@@ -206,6 +217,7 @@ class ApplicationConfig(ExtraForbidModel):
                 "GPT4O_MINI_DEPLOYMENTS",
                 "AZURE_AI_VISION_DEPLOYMENTS",
                 "NON_STREAMING_DEPLOYMENTS",
+                "HEADERS_TO_PROXY",
             )
         }
 

--- a/aidial_adapter_openai/endpoints/chat_completion.py
+++ b/aidial_adapter_openai/endpoints/chat_completion.py
@@ -95,10 +95,7 @@ async def call_chat_completion(
     deployment_type, endpoint = deployment.deployment_type, deployment.endpoint
 
     creds = await get_credentials(request_headers)
-
-    headers_to_proxy = {}
-    if user_id := request_headers.get("x-user-id"):
-        headers_to_proxy["x-user-id"] = user_id
+    headers_to_proxy = app_config.get_headers_to_proxy(request_headers)
 
     client = endpoint.get_client(
         {**creds, "api_version": api_version, "headers": headers_to_proxy}

--- a/aidial_adapter_openai/endpoints/chat_completion.py
+++ b/aidial_adapter_openai/endpoints/chat_completion.py
@@ -95,7 +95,14 @@ async def call_chat_completion(
     deployment_type, endpoint = deployment.deployment_type, deployment.endpoint
 
     creds = await get_credentials(request_headers)
-    client = endpoint.get_client({**creds, "api_version": api_version})
+
+    headers_to_proxy = {}
+    if user_id := request_headers.get("x-user-id"):
+        headers_to_proxy["x-user-id"] = user_id
+
+    client = endpoint.get_client(
+        {**creds, "api_version": api_version, "headers": headers_to_proxy}
+    )
 
     def _get_tokenizer() -> Tokenizer:
         tiktoken_model = app_config.TIKTOKEN_MODEL_MAPPING.get(

--- a/aidial_adapter_openai/utils/parsers.py
+++ b/aidial_adapter_openai/utils/parsers.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 
 from aidial_sdk.exceptions import HTTPException, InvalidRequestError
 from fastapi import Request
-from openai import AsyncAzureOpenAI, AsyncOpenAI, Timeout
+from openai import AsyncAzureOpenAI, AsyncOpenAI
 from typing_extensions import TypedDict
 
 from aidial_adapter_openai.utils.http_client import get_http_client
@@ -17,7 +17,7 @@ class OpenAIParams(TypedDict, total=False):
     api_key: str
     azure_ad_token: str
     api_version: str
-    timeout: Timeout
+    headers: dict[str, str]
 
 
 # Retries are handled on the DIAL Core side
@@ -37,8 +37,8 @@ class AzureOpenAIEndpoint(ExtraForbidModel):
             api_key=params.get("api_key"),
             azure_ad_token=params.get("azure_ad_token"),
             api_version=params.get("api_version"),
-            timeout=params.get("timeout"),
             max_retries=_MAX_RETRIES,
+            default_headers=params.get("headers"),
             http_client=get_http_client(),
         )
 
@@ -52,8 +52,8 @@ class OpenAIEndpoint(ExtraForbidModel):
         return AsyncOpenAI(
             base_url=self.base_url,
             api_key=api_key,
-            timeout=params.get("timeout"),
             max_retries=_MAX_RETRIES,
+            default_headers=params.get("headers"),
             http_client=get_http_client(),
         )
 


### PR DESCRIPTION
Similar to the env var of the same name in the [DIAL adapter](https://github.com/epam/ai-dial-adapter-dial/?tab=readme-ov-file#environment-variables).

Integration with vLLM requires proxying of `x-user-id` header from the client to the vLLM router.
This is a simple fix to achieve this functionality.
However, it seems like we also need to support tokenisation (`max_prompt_tokens` field), which is required for DIAL RAG.
So we should probably create a native integration with vLLM that provides [Tokenizer API](https://docs.vllm.ai/en/stable/serving/openai_compatible_server/#tokenizer-api).