### PR TITLE
chore: bump zlib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ RUN apk upgrade --no-cache libexpat
 RUN pip install setuptools==80.10.2
 # fix CVE-2026-24049
 RUN pip install wheel==0.46.2
-# fix CVE-2025-6965
-RUN apk upgrade --no-cache sqlite-libs
+# fix CVE-2025-6965 and CVE-2026-22184
+RUN apk upgrade --no-cache sqlite-libs zlib
 
 WORKDIR /app
 


### PR DESCRIPTION
Fixes vulnerability highlighted by Trivy:

```
ghcr.io/epam/ai-dial-adapter-openai:test (alpine 3.23.3)
========================================================
Total: 1 (HIGH: 0, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ zlib    │ CVE-2026-22184 │ CRITICAL │ fixed  │ 1.3.1-r2          │ 1.3.2-r0      │ zlib: zlib: Arbitrary code execution via buffer overflow in │
│         │                │          │        │                   │               │ untgz utility                                               │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-22184                  │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘
```