### PR TITLE
chore: add .gitattributes to enforce LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure shell scripts always use LF line endings, even on Windows checkouts
+*.sh text eol=lf
+


### PR DESCRIPTION
### Description of changes

- Added `.gitattributes` rule to enforce LF line endings for shell scripts:
  - `*.sh text eol=lf`
- This prevents common cross-platform failures when running scripts checked out on Windows (e.g., `/bin/bash^M` caused by CRLF).
- No application logic changes; this is a repository hygiene/configuration update.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
