### PR TITLE
feat: Claude: support automatic caching and `ttl` parameter in cache breakpoints

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -67,3 +67,6 @@ resolutions:
     - message: ".*PyPI::aidial-adapter-anthropic.*"
       reason: "CANT_FIX_EXCEPTION"
       comment: "ORT cannot pick up license information"
+    - message: ".*PyPI::aidial-sdk.*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "ORT cannot pick up license information"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@
       - [Qwen3-ASR](#qwen3-asr)
     - [Anthropic Messages API](#anthropic-messages-api)
       - [Default `max_tokens` for Claude models](#default-max_tokens-for-claude-models)
+      - [Automatic prompt caching](#automatic-prompt-caching)
+      - [Explicit prompt caching](#explicit-prompt-caching)
   - [Tokenization of chat completion requests/responses](#tokenization-of-chat-completion-requestsresponses)
     - [How to minimize adapter-side tokenization](#how-to-minimize-adapter-side-tokenization)
     - [Tokenization algorithm](#tokenization-algorithm)
@@ -799,6 +801,84 @@ Such a **per-model** configuration is operationally cleaner since all the inform
 The default value set in the DIAL Core Config takes precedence over the one configured in the adapter.
 
 Make sure the default doesn't exceed Claude's [max output tokens](https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table), otherwise, you will receive an error like this one: `max_tokens: 10000 > 8192, which is the maximum allowed number of output tokens for claude-...)`.
+
+##### Automatic prompt caching
+
+The adapter supports [automatic prompt caching](https://github.com/epam/ai-dial-adapter-anthropic/#automatic-caching).
+
+To enable it:
+
+- Configure a top-level cache breakpoint in the chat completion request via `defaults.custom_fields.cache_breakpoint`.
+- If the DIAL deployment uses multiple upstreams, set `autoCachingSupported: true` in the DIAL Core configuration.
+
+<details><summary>DIAL Core Config</summary>
+
+```json
+{
+  "models": {
+    "${DIAL_DEPLOYMENT_ID}": {
+      "type": "chat",
+      "overrideName": "${ANTHROPIC_MODEL_NAME}",
+      "defaults": {
+        "custom_fields": {
+          "cache_breakpoint": {}
+        }
+      },
+      "endpoint": "${ADAPTER_ORIGIN}/openai/deployments/${ADAPTER_DEPLOYMENT_ID}/chat/completions",
+      "upstreams": [
+        {
+          "endpoint": "https://${AZURE_AI_FOUNDRY_SERVICE_NAME1}.services.ai.azure.com/anthropic/v1/messages",
+          "key": "${OPTIONAL_API_KEY1}"
+        },
+        {
+          "endpoint": "https://${AZURE_AI_FOUNDRY_SERVICE_NAME2}.services.ai.azure.com/anthropic/v1/messages",
+          "key": "${OPTIONAL_API_KEY2}"
+        }
+      ],
+      "features": {
+        "autoCachingSupported": true
+      }
+    }
+  }
+}
+```
+
+</details>
+
+##### Explicit prompt caching
+
+The adapter support explicit cache breakpoints in system and user message as well as in the tool definitions. Find the [examples of requests](https://github.com/epam/ai-dial-adapter-anthropic/#explicit-cache-breakpoints) in the Anthropic adapter documentation.
+
+Set the feature flag `cacheSupported: true` in the DIAL Core configuration, when the DIAL deployment has multiple upstreams. This flag enables logic in DIAL Core that routes chat completions requests with the same prefixes to the same upstreams:
+
+<details><summary>DIAL Core Config</summary>
+
+```json
+{
+  "models": {
+    "${DIAL_DEPLOYMENT_ID}": {
+      "type": "chat",
+      "overrideName": "${ANTHROPIC_MODEL_NAME}",
+      "endpoint": "${ADAPTER_ORIGIN}/openai/deployments/${ADAPTER_DEPLOYMENT_ID}/chat/completions",
+      "upstreams": [
+        {
+          "endpoint": "https://${AZURE_AI_FOUNDRY_SERVICE_NAME1}.services.ai.azure.com/anthropic/v1/messages",
+          "key": "${OPTIONAL_API_KEY1}"
+        },
+        {
+          "endpoint": "https://${AZURE_AI_FOUNDRY_SERVICE_NAME2}.services.ai.azure.com/anthropic/v1/messages",
+          "key": "${OPTIONAL_API_KEY2}"
+        }
+      ],
+      "features": {
+        "cacheSupported": true
+      }
+    }
+  }
+}
+```
+
+</details>
 
 ### Tokenization of chat completion requests/responses
 

--- a/aidial_adapter_openai/responses/converter.py
+++ b/aidial_adapter_openai/responses/converter.py
@@ -2,12 +2,8 @@ from collections.abc import Generator
 from typing import assert_never
 
 import pydantic
-from aidial_sdk.chat_completion.request import (
-    Attachment,
-    CustomContent,
-    Stage,
-    Status,
-)
+from aidial_sdk.chat_completion.enums import Status
+from aidial_sdk.chat_completion.request import Attachment, CustomContent, Stage
 from aidial_sdk.exceptions import RequestValidationError
 from openai.types.chat import (
     ChatCompletion,

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,33 +2,33 @@
 
 [[package]]
 name = "aidial-adapter-anthropic"
-version = "0.6.0"
+version = "0.7.0"
 description = "Package implementing adapter from DIAL Chat Completions API to Anthropic API"
 optional = false
 python-versions = "<4.0,>=3.11"
 groups = ["main"]
 files = [
-    {file = "aidial_adapter_anthropic-0.6.0-py3-none-any.whl", hash = "sha256:07ec0b73d89f99e67b78b4126b7123b4470232f0f22ccc245d9e9d00e84fbfce"},
-    {file = "aidial_adapter_anthropic-0.6.0.tar.gz", hash = "sha256:6db2c6d2e2d78af70f52247608289c7b58c43c41452a63d149583801596dc18d"},
+    {file = "aidial_adapter_anthropic-0.7.0-py3-none-any.whl", hash = "sha256:e2c03ec562f2e10f76766f404ee6f48de5a651c09fe912267534f42189599ff4"},
+    {file = "aidial_adapter_anthropic-0.7.0.tar.gz", hash = "sha256:f2a44e322ad49c6fbdb33db57174e4e4b254e9df238877c6e49f860eb32188bd"},
 ]
 
 [package.dependencies]
-aidial-sdk = ">=0.28.0,<1"
+aidial-sdk = ">=0.35.0,<1"
 aiohttp = ">=3.13.3,<4"
-anthropic = ">=0.79.0,<1"
+anthropic = ">=0.95.0,<1"
 pillow = ">=10.4.0,<13"
 pydantic = ">=2.8.2,<3"
 
 [[package]]
 name = "aidial-sdk"
-version = "0.32.0"
+version = "0.35.0"
 description = "Framework to create applications and model adapters for AI DIAL"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "aidial_sdk-0.32.0-py3-none-any.whl", hash = "sha256:6d6cee07ea4a932a27e0f0fdf69cef5ecd34569fb492c18392c6277c75d7a548"},
-    {file = "aidial_sdk-0.32.0.tar.gz", hash = "sha256:ea952aab6722d4524783d10e5d7379833f8b1f1f2f6c28bfd53375fa746b5764"},
+    {file = "aidial_sdk-0.35.0-py3-none-any.whl", hash = "sha256:94f9e57284c74231a9a1e6efac22142247059a09892c4166fa05877dfc4263ab"},
+    {file = "aidial_sdk-0.35.0.tar.gz", hash = "sha256:85e2ffdbdf03440970b1550b5181df1ac55179dbfb6b8e68b6a8dbd40fb01727"},
 ]
 
 [package.dependencies]
@@ -281,14 +281,14 @@ files = [
 
 [[package]]
 name = "anthropic"
-version = "0.79.0"
+version = "0.95.0"
 description = "The official Python library for the anthropic API"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "anthropic-0.79.0-py3-none-any.whl", hash = "sha256:04cbd473b6bbda4ca2e41dd670fe2f829a911530f01697d0a1e37321eb75f3cf"},
-    {file = "anthropic-0.79.0.tar.gz", hash = "sha256:8707aafb3b1176ed6c13e2b1c9fb3efddce90d17aee5d8b83a86c70dcdcca871"},
+    {file = "anthropic-0.95.0-py3-none-any.whl", hash = "sha256:9fd3503cb666446e28ab5a5d0ec7feda39968399e494bd2cca2f0b927f8aa7a6"},
+    {file = "anthropic-0.95.0.tar.gz", hash = "sha256:e4d815351489e5627f39806f12561c52b574e69be10d12fcab723264f955c11d"},
 ]
 
 [package.dependencies]
@@ -299,11 +299,13 @@ httpx = ">=0.25.0,<1"
 jiter = ">=0.4.0,<1"
 pydantic = ">=1.9.0,<3"
 sniffio = "*"
-typing-extensions = ">=4.10,<5"
+typing-extensions = ">=4.14,<5"
 
 [package.extras]
 aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.9)"]
+aws = ["boto3 (>=1.28.57)", "botocore (>=1.31.57)"]
 bedrock = ["boto3 (>=1.28.57)", "botocore (>=1.31.57)"]
+mcp = ["mcp (>=1.0) ; python_version >= \"3.10\""]
 vertex = ["google-auth[requests] (>=2,<3)"]
 
 [[package]]
@@ -3324,4 +3326,4 @@ test = ["big-O", "importlib-resources ; python_version < \"3.9\"", "jaraco.funct
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "d4a6a59641396ba82b2bcfd9c1ab1bedde9d1664633aa35cc96dc788684c4154"
+content-hash = "2a0de5e4dd09ba6d947e5f2902d85f3e3b839ad48ed5469876791ccd39b72231"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,9 @@ pillow = "12.2.0"
 azure-identity = "1.16.1"
 # The default async transport in `azure-identity` is `aiohttp`
 aiohttp = "3.13.4"
-aidial-sdk = { version = "0.32.0", extras = ["telemetry"] }
-aidial-adapter-anthropic = { version = "0.6.0" }
-anthropic = "0.79.0"
+aidial-sdk = { version = "0.35.0", extras = ["telemetry"] }
+aidial-adapter-anthropic = { version = "0.7.0" }
+anthropic = "0.95.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = "9.0.3"

--- a/tests/integration_tests/base.py
+++ b/tests/integration_tests/base.py
@@ -70,7 +70,7 @@ class Env(ExtraAllowedModel):
 class ModelConfig(ExtraAllowedModel):
     type: Literal["chat", "embedding"]
     overrideName: str | None = None
-    defaults: dict
+    defaults: dict | None = None
     upstreams: list[UpstreamConfig]
     features: Features = Features()
     env: Env = Env()

--- a/tests/integration_tests/base.py
+++ b/tests/integration_tests/base.py
@@ -36,6 +36,7 @@ class Features(ExtraAllowedModel):
     toolsSupported: bool = True
     parallelToolCallsSupported: bool = True
     temperatureSupported: bool = True
+    autoCachingSupported: bool = False
 
     # Not in the DIAL Core config yet
     maxTokensSupported: bool = True
@@ -69,6 +70,7 @@ class Env(ExtraAllowedModel):
 class ModelConfig(ExtraAllowedModel):
     type: Literal["chat", "embedding"]
     overrideName: str | None = None
+    defaults: dict
     upstreams: list[UpstreamConfig]
     features: Features = Features()
     env: Env = Env()
@@ -122,6 +124,7 @@ class DeploymentConfig(BaseModel, Generic[_T]):
     type_: _T
 
     model_name: str
+    model_defaults: dict | None
     model_features: Features
     model_attachments: list[str] | None
 
@@ -158,6 +161,7 @@ class DeploymentConfig(BaseModel, Generic[_T]):
                         upstream_idx=upstream_idx,
                         id_=deployment_id,
                         model_name=model_config.overrideName or deployment_id,
+                        model_defaults=model_config.defaults,
                         model_features=model_config.features,
                         model_attachments=model_config.inputAttachmentTypes,
                         type_=get_deployment_type(
@@ -207,6 +211,10 @@ class DeploymentConfig(BaseModel, Generic[_T]):
     @property
     def supports_reasoning(self):
         return self.model_features.reasoningSupported
+
+    @property
+    def supports_auto_caching(self):
+        return self.model_features.autoCachingSupported
 
 
 class TestDeployments(BaseModel):

--- a/tests/integration_tests/chat_completion/test_case.py
+++ b/tests/integration_tests/chat_completion/test_case.py
@@ -182,3 +182,7 @@ class TestSuite:
     @property
     def supports_response_format_json_schema(self):
         return self.deployment_config.model_features.responseFormatJsonSchemaSupported
+
+    @property
+    def supports_auto_caching(self):
+        return self.deployment_config.model_features.autoCachingSupported

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -3,6 +3,7 @@ import pytest
 from openai import AsyncAzureOpenAI
 
 from tests.integration_tests.base import DeploymentConfig
+from tests.utils.http_client import with_request_overrides
 
 
 @pytest.fixture
@@ -14,7 +15,9 @@ def create_openai_client(test_app: httpx.AsyncClient):
             api_version="2024-12-01-preview",
             api_key="dummy_key",
             max_retries=3,
-            http_client=test_app,
+            http_client=with_request_overrides(
+                test_app, deployment_config.model_defaults
+            ),
             default_headers=deployment_config.upstream_headers,
         )
 

--- a/tests/integration_tests/integration_test_config_example.json
+++ b/tests/integration_tests/integration_test_config_example.json
@@ -332,6 +332,11 @@
             }
         },
         "claude-sonnet-4-520250929": {
+            "defaults": {
+                "custom_fields": {
+                    "cache_breakpoint": {}
+                }
+            },
             "type": "chat",
             "upstreams": [
                 {
@@ -342,7 +347,8 @@
             "features": {
                 "responseFormatJsonObjectSupported": false,
                 "responseFormatJsonSchemaSupported": true,
-                "emptyDialogSupported": false
+                "emptyDialogSupported": false,
+                "autoCachingSupported": true
             },
             "inputAttachmentTypes": [
                 "image/*"

--- a/tests/integration_tests/test_prompt_caching.py
+++ b/tests/integration_tests/test_prompt_caching.py
@@ -14,6 +14,7 @@ from tests.integration_tests.base import DeploymentConfig
 from tests.integration_tests.constants import (
     TEST_DEPLOYMENTS_CONFIG,
 )
+from tests.utils.fixtures import maybe_parametrized_fixture
 from tests.utils.openai import ai, chat_completion, sys, user
 
 D = DeploymentConfig[ChatCompletionDeploymentType]
@@ -24,19 +25,14 @@ _auto_caching_deployments: list[D] = [
     if d.model_features.autoCachingSupported
 ]
 
-if _auto_caching_deployments:
 
-    @pytest.fixture(
-        params=_auto_caching_deployments, ids=lambda d: d.display_config()
-    )
-    def auto_caching_deployment(request) -> D:
-        return request.param
-
-else:
-
-    @pytest.fixture
-    def auto_caching_deployment(request) -> D:
-        pytest.skip("No auto-caching deployments were found")
+@maybe_parametrized_fixture(
+    params=_auto_caching_deployments,
+    ids=lambda d: d.display_config(),
+    skip_reason="No auto-caching deployments were found",
+)
+def auto_caching_deployment(deployment: D) -> D:
+    return deployment
 
 
 @pytest.fixture(params=[True, False], ids=["stream", "block"])

--- a/tests/integration_tests/test_prompt_caching.py
+++ b/tests/integration_tests/test_prompt_caching.py
@@ -1,0 +1,99 @@
+import random
+from collections.abc import Callable
+
+import openai
+import pytest
+from openai.types.chat import (
+    ChatCompletionMessageParam,
+)
+
+from aidial_adapter_openai.configuration.deployment_type import (
+    ChatCompletionDeploymentType,
+)
+from tests.integration_tests.base import DeploymentConfig
+from tests.integration_tests.constants import (
+    TEST_DEPLOYMENTS_CONFIG,
+)
+from tests.utils.openai import ai, chat_completion, sys, user
+
+D = DeploymentConfig[ChatCompletionDeploymentType]
+
+_auto_caching_deployments: list[D] = [
+    d
+    for d in TEST_DEPLOYMENTS_CONFIG.chat_deployments
+    if d.model_features.autoCachingSupported
+]
+
+if _auto_caching_deployments:
+
+    @pytest.fixture(
+        params=_auto_caching_deployments, ids=lambda d: d.display_config()
+    )
+    def auto_caching_deployment(request) -> D:
+        return request.param
+
+else:
+
+    @pytest.fixture
+    def auto_caching_deployment(request) -> D:
+        pytest.skip("No auto-caching deployments were found")
+
+
+@pytest.fixture(params=[True, False], ids=["stream", "block"])
+def stream(request) -> bool:
+    return request.param
+
+
+def _pseudo_random(seed: int, a: int = 0, b: int = 100) -> int:
+    return random.Random(seed).randrange(a, b + 1)  # noqa: S311
+
+
+def _create_prompt(n: int) -> tuple[str, dict[int, int]]:
+    lines = []
+    answers = {}
+    for idx in range(1, n + 1):
+        x = _pseudo_random(2 * idx)
+        y = _pseudo_random(2 * idx + 1)
+        lines.append(f"[{idx}] {x} + {y} = ?")
+        answers[idx] = x + y
+    return "\n".join(lines), answers
+
+
+async def test_auto_caching(
+    create_openai_client: Callable[..., openai.AsyncAzureOpenAI],
+    auto_caching_deployment: D,
+    stream: bool,
+) -> None:
+    message, answers = _create_prompt(400)
+
+    messages: list[ChatCompletionMessageParam] = [sys(message)]
+
+    indices = [151, 132, 267]
+    for i, idx in enumerate(indices):
+        query = f"Print the expression [{idx}] and compute it."
+        answer = str(answers[idx])
+
+        messages.append(user(query))
+
+        response = await chat_completion(
+            create_openai_client(auto_caching_deployment),
+            stream=stream,
+            deployment_id=auto_caching_deployment.model_name,
+            messages=messages,
+            max_tokens=512,
+        )
+        assert answer in response.content
+
+        messages.append(ai(response.content))
+
+        assert response.usage is not None
+
+        # Make sure the prompt size is over the token threshold that triggers the implicit caching:
+        # * https://platform.claude.com/docs/en/build-with-claude/prompt-caching#cache-limitations (max threshold is 4096 tokens)
+        # https://developers.openai.com/api/docs/guides/prompt-caching#how-it-works (enabled from 1024 tokens)
+        assert response.usage.prompt_tokens >= 4_096
+
+        if i:
+            assert (details := response.usage.prompt_tokens_details) is not None
+            assert (cached := details.cached_tokens) is not None
+            assert cached > 0

--- a/tests/utils/fixtures.py
+++ b/tests/utils/fixtures.py
@@ -1,0 +1,25 @@
+from collections.abc import Callable, Sequence
+from typing import TypeVar
+
+import pytest
+
+_T = TypeVar("_T")
+
+
+def maybe_parametrized_fixture(
+    *, params: Sequence[_T], ids: Callable[[_T], str], skip_reason: str
+):
+    def decorator(func):
+        @pytest.fixture(
+            params=list(params) or [None],
+            ids=lambda x: ids(x) if x is not None else "none",
+        )
+        def wrapper(request):
+            value = request.param
+            if value is None:
+                pytest.skip(skip_reason)
+            return func(value)
+
+        return wrapper
+
+    return decorator

--- a/tests/utils/http_client.py
+++ b/tests/utils/http_client.py
@@ -25,21 +25,22 @@ def with_request_overrides(
         if "application/json" not in content_type:
             return
 
-        if request.content is None:
-            return
-
+        body = await request.aread()
         try:
-            body = json.loads(request.content)
+            data = json.loads(body)
         except Exception:
             return
 
-        if not isinstance(body, dict):
+        if not isinstance(data, dict):
             return
 
-        merged = _merge_defaults_inplace(body, defaults)
+        _merge_defaults_inplace(data, defaults)
 
-        request._content = json.dumps(merged).encode("utf-8")
-        request.headers["content-length"] = str(len(request.content))
+        new_body = json.dumps(data).encode("utf-8")
+
+        request._content = new_body
+        request.stream = httpx.ByteStream(new_body)
+        request.headers["content-length"] = str(len(new_body))
 
     new_hooks = dict(client.event_hooks)
     new_hooks.setdefault("request", []).append(on_request)

--- a/tests/utils/http_client.py
+++ b/tests/utils/http_client.py
@@ -1,0 +1,53 @@
+import json
+from copy import deepcopy
+
+import httpx
+
+
+def _merge_defaults_inplace(dst: dict, defaults: dict) -> dict:
+    """Recursively apply defaults into dst (without overriding existing keys)."""
+    for k, v in defaults.items():
+        if k not in dst:
+            dst[k] = deepcopy(v)
+        elif isinstance(dst[k], dict) and isinstance(v, dict):
+            _merge_defaults_inplace(dst[k], v)
+    return dst
+
+
+def with_request_overrides(
+    client: httpx.AsyncClient, defaults: dict | None
+) -> httpx.AsyncClient:
+    if defaults is None:
+        return client
+
+    async def on_request(request: httpx.Request):
+        content_type = request.headers.get("content-type", "")
+        if "application/json" not in content_type:
+            return
+
+        if request.content is None:
+            return
+
+        try:
+            body = json.loads(request.content)
+        except Exception:
+            return
+
+        if not isinstance(body, dict):
+            return
+
+        merged = _merge_defaults_inplace(body, defaults)
+
+        request._content = json.dumps(merged).encode("utf-8")
+        request.headers["content-length"] = str(len(request.content))
+
+    new_hooks = dict(client.event_hooks)
+    new_hooks.setdefault("request", []).append(on_request)
+
+    return httpx.AsyncClient(
+        transport=client._transport,
+        headers=client.headers,
+        timeout=client.timeout,
+        event_hooks=new_hooks,
+        base_url=client.base_url,
+    )


### PR DESCRIPTION
Effectively, the fix bumps `aidial-adapter-anthropic` from 0.6.0 to 0.7.0 to pick up support of automatic caching: https://github.com/epam/ai-dial-adapter-anthropic/pull/33

The rest are the fixes to the integration tests and documentation.