### PR TITLE
fix!: deprecate DIAL_USE_FILE_STORAGE env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1197,8 +1197,7 @@ Deployments that do not fall into any of the categories are considered to suppor
 |---|---|---|
 |LOG_LEVEL|INFO|Log level. Use DEBUG for dev purposes and INFO in prod|
 |TIKTOKEN_MODEL_MAPPING|`{}`|A JSON dictionary from the request deployment id to a [tiktoken model name](https://github.com/openai/tiktoken/blob/main/tiktoken/model.py). It's used for [tokenization](#tokenization-of-chat-completion-requestsresponses) of chat completion requests on the adapter side. Example: `{"my-gpt-deployment":"gpt-3.5-turbo","my-gpt-o3-deployment":"o3"}`. The tokenizer for `gpt-4o` is used as a default.|
-|DIAL_USE_FILE_STORAGE|False|Save image model artifacts to DIAL File storage (DALL-E images are uploaded to the DIAL file storage and its base64 encodings are replaced with links to the storage)|
-|DIAL_URL||URL of the core DIAL server (required when `DIAL_USE_FILE_STORAGE=True`)|
+|DIAL_URL||URL of the [DIAL Core](https://github.com/epam/ai-dial-core/) server. When set, it enables uploading and downloading of DIAL Files to and from DIAL Storage.|
 |NON_STREAMING_DEPLOYMENTS|``|Comma-separated list of deployments that do not support streaming. The adapter will emulate streaming by calling the model and converting its response into a single-chunk stream. Example: `"o1-mini,o1-preview"`|
 |ACCESS_TOKEN_EXPIRATION_WINDOW|10|The Azure access token is renewed this many seconds before its actual expiration time. The buffer ensures that the token does not expire in the middle of an operation due to processing time and potential network delays.|
 |AZURE_OPEN_AI_SCOPE||Provided scope of access token to Azure OpenAI services. Default: `https://cognitiveservices.azure.com/.default`|

--- a/aidial_adapter_openai/configuration/deprecations.py
+++ b/aidial_adapter_openai/configuration/deprecations.py
@@ -17,6 +17,11 @@ In the unlikely case that the deployments declared under this variable are still
         f"{_gpt4_deprecation_message} "
         f"The variable is of no use, it could be safely removed."
     ),
+    "DIAL_USE_FILE_STORAGE": (
+        "Previously, 'DIAL_USE_FILE_STORAGE=True' explicitly enabled DIAL Storage, and 'DIAL_USE_FILE_STORAGE=False' or leaving it unset disabled it. "
+        "After the change, DIAL Storage is enabled automatically when 'DIAL_URL' is set. 'DIAL_USE_FILE_STORAGE' is deprecated and no longer forces storage to be enabled when 'DIAL_URL' is missing. "
+        "'DIAL_USE_FILE_STORAGE' is of no use, it could be safely removed."
+    ),
 }
 
 

--- a/aidial_adapter_openai/configuration/deprecations.py
+++ b/aidial_adapter_openai/configuration/deprecations.py
@@ -18,8 +18,7 @@ In the unlikely case that the deployments declared under this variable are still
         f"The variable is of no use, it could be safely removed."
     ),
     "DIAL_USE_FILE_STORAGE": (
-        "Previously, 'DIAL_USE_FILE_STORAGE=True' explicitly enabled DIAL Storage, and 'DIAL_USE_FILE_STORAGE=False' or leaving it unset disabled it. "
-        "After the change, DIAL Storage is enabled automatically when 'DIAL_URL' is set. 'DIAL_USE_FILE_STORAGE' is deprecated and no longer forces storage to be enabled when 'DIAL_URL' is missing. "
+        "The DIAL Storage is enabled automatically when 'DIAL_URL' is set. 'DIAL_USE_FILE_STORAGE' is deprecated and no longer forces storage to be enabled when 'DIAL_URL' is missing. "
         "'DIAL_USE_FILE_STORAGE' is of no use, it could be safely removed."
     ),
 }

--- a/aidial_adapter_openai/dial_api/storage.py
+++ b/aidial_adapter_openai/dial_api/storage.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import mimetypes
+import os
 from collections.abc import Mapping
 from urllib.parse import unquote, urljoin
 
@@ -9,7 +10,6 @@ from aidial_sdk.exceptions import InvalidRequestError
 from pydantic import BaseModel, SecretStr
 from typing_extensions import TypedDict
 
-from aidial_adapter_openai.utils.env import get_env, get_env_bool
 from aidial_adapter_openai.utils.http_client import get_http_client
 from aidial_adapter_openai.utils.log_config import logger as log
 
@@ -140,17 +140,11 @@ def _compute_hash_digest(file_content: str | bytes) -> str:
     return hashlib.sha256(file_content).hexdigest()
 
 
-DIAL_USE_FILE_STORAGE = get_env_bool("DIAL_USE_FILE_STORAGE", False)
-
-DIAL_URL: str | None = None
-if DIAL_USE_FILE_STORAGE:
-    DIAL_URL = get_env(
-        "DIAL_URL", "DIAL_URL must be set to use the DIAL file storage"
-    )
+DIAL_URL = os.getenv("DIAL_URL")
 
 
 def create_file_storage(headers: Mapping[str, str]) -> FileStorage | None:
-    if not DIAL_USE_FILE_STORAGE or DIAL_URL is None:
+    if DIAL_URL is None:
         return None
 
     if (api_key := headers.get("api-key")) is None:


### PR DESCRIPTION
Resolves #325 

Previously, `DIAL_USE_FILE_STORAGE=True` explicitly enabled DIAL Storage, and `DIAL_USE_FILE_STORAGE=False` or leaving it unset disabled it.

After the change, DIAL Storage is enabled automatically when `DIAL_URL` is set. `DIAL_USE_FILE_STORAGE` is deprecated and no longer forces storage to be enabled when `DIAL_URL` is missing.

The following table shows which combination of env variables leads to which behaviour before and after the fix, along with the migration steps required to preserve the behavior before the fix:

|`DIAL_USE_FILE_STORAGE`|`DIAL_URL`|Before|After|Migration|
|---|---|---|---|---|
|`False`/unset|set|DIAL Storage is disabled|DIAL Storage is enabled|unset `DIAL_URL`|
|`False`/unset|unset|DIAL Storage is disabled|DIAL Storage is disabled|nothing to do|
|`True`|unset|Error: `DIAL_URL must be set to use the DIAL file storage`|DIAL Storage is disabled|nothing to do|
|`True`|set|DIAL Storage is enabled|DIAL Storage is enabled|nothing to do|
