### PR TITLE
fix: Responses-to-Responses API: support string input

### DIFF
--- a/aidial_adapter_openai/responses/request.py
+++ b/aidial_adapter_openai/responses/request.py
@@ -66,7 +66,7 @@ class AttachmentRule:
     dst_field: str | None = None
 
     async def apply(self, file_storage: FileStorage, request: Any) -> None:
-        for obj in _compile_jmespath(self.path).search(request):
+        for obj in _compile_jmespath(self.path).search(request) or []:
             if not isinstance(obj, dict):
                 continue
 

--- a/tests/unit_tests/test_responses_attachments.py
+++ b/tests/unit_tests/test_responses_attachments.py
@@ -1,4 +1,5 @@
 import base64
+import copy
 import re
 from dataclasses import dataclass
 from unittest.mock import patch
@@ -168,13 +169,38 @@ class TestDownloadDialUrlsInRequestSuccess:
         ) as router:
             yield router.get(pattern).respond(text="file-content")
 
-    async def test_download_dial_urls_string_input(self, file_storage):
-        request = _message("input string", with_type=False)
-
-        result = await download_dial_urls_in_request(file_storage, request)
-        content = result["input"][0]["content"]  # type: ignore
-
-        assert content == "input string"
+    @pytest.mark.parametrize(
+        "req",
+        [
+            ResponseCreateParamsBase(
+                model="test-model",
+                input="input string",
+            ),
+            ResponseCreateParamsBase(
+                model="test-model",
+                input=[{"role": "user", "content": "user message"}],
+            ),
+            ResponseCreateParamsBase(
+                model="test-model",
+                input=[
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": "user message"}
+                        ],
+                    }
+                ],
+            ),
+        ],
+        ids=["string input", "easy input message", "input_text content part"],
+    )
+    async def test_download_dial_urls_noop(
+        self, file_storage, req: ResponseCreateParamsBase
+    ):
+        request = copy.deepcopy(req)
+        result = await download_dial_urls_in_request(file_storage, req)
+        assert request == result
 
     async def test_download_dial_urls_in_request_message_image(
         self, file_storage, with_type: bool, url_case: UrlCase

--- a/tests/unit_tests/test_responses_attachments.py
+++ b/tests/unit_tests/test_responses_attachments.py
@@ -14,7 +14,6 @@ from openai.types.responses import (
     ResponseInputFileParam,
     ResponseInputImageContentParam,
     ResponseInputImageParam,
-    ResponseInputItemParam,
 )
 from openai.types.responses.response_create_params import (
     ResponseCreateParamsBase,
@@ -67,18 +66,12 @@ def _file_content(url: str) -> ResponseInputFileContentParam:
 
 
 def _message(
-    content: ResponseInputMessageContentListParam | str, with_type: bool
+    content: ResponseInputMessageContentListParam, with_type: bool
 ) -> ResponseCreateParamsBase:
-    def _to_input() -> list[ResponseInputItemParam] | str:
-        if isinstance(content, str):
-            return content
-        else:
-            message = Message(role="user", content=content)
-            if with_type:
-                message["type"] = "message"
-            return [message]
-
-    return ResponseCreateParamsBase(model="test-model", input=_to_input())
+    message = Message(role="user", content=content)
+    if with_type:
+        message["type"] = "message"
+    return ResponseCreateParamsBase(model="test-model", input=[message])
 
 
 def _function_call(
@@ -198,9 +191,10 @@ class TestDownloadDialUrlsInRequestSuccess:
     async def test_download_dial_urls_noop(
         self, file_storage, req: ResponseCreateParamsBase
     ):
-        request = copy.deepcopy(req)
-        result = await download_dial_urls_in_request(file_storage, req)
-        assert request == result
+        result = await download_dial_urls_in_request(
+            file_storage, copy.deepcopy(req)
+        )
+        assert req == result
 
     async def test_download_dial_urls_in_request_message_image(
         self, file_storage, with_type: bool, url_case: UrlCase

--- a/tests/unit_tests/test_responses_attachments.py
+++ b/tests/unit_tests/test_responses_attachments.py
@@ -13,6 +13,7 @@ from openai.types.responses import (
     ResponseInputFileParam,
     ResponseInputImageContentParam,
     ResponseInputImageParam,
+    ResponseInputItemParam,
 )
 from openai.types.responses.response_create_params import (
     ResponseCreateParamsBase,
@@ -65,12 +66,18 @@ def _file_content(url: str) -> ResponseInputFileContentParam:
 
 
 def _message(
-    content: ResponseInputMessageContentListParam, with_type: bool
+    content: ResponseInputMessageContentListParam | str, with_type: bool
 ) -> ResponseCreateParamsBase:
-    message = Message(role="user", content=content)
-    if with_type:
-        message["type"] = "message"
-    return ResponseCreateParamsBase(model="test-model", input=[message])
+    def _to_input() -> list[ResponseInputItemParam] | str:
+        if isinstance(content, str):
+            return content
+        else:
+            message = Message(role="user", content=content)
+            if with_type:
+                message["type"] = "message"
+            return [message]
+
+    return ResponseCreateParamsBase(model="test-model", input=_to_input())
 
 
 def _function_call(
@@ -160,6 +167,14 @@ class TestDownloadDialUrlsInRequestSuccess:
             assert_all_mocked=True,
         ) as router:
             yield router.get(pattern).respond(text="file-content")
+
+    async def test_download_dial_urls_string_input(self, file_storage):
+        request = _message("input string", with_type=False)
+
+        result = await download_dial_urls_in_request(file_storage, request)
+        content = result["input"][0]["content"]  # type: ignore
+
+        assert content == "input string"
 
     async def test_download_dial_urls_in_request_message_image(
         self, file_storage, with_type: bool, url_case: UrlCase


### PR DESCRIPTION
**Before**: the following request to `POST /openai/v1/responses`

```json
{
    "model": "gpt-5.4-2026-03-05",
    "input": "test"
}
```

Led to the following error

```txt
2026-05-15T11:51:56.540459221Z   File "/app/aidial_adapter_openai/endpoints/responses.py", line 69, in responses_create
2026-05-15T11:51:56.540468345Z     request_body = await download_dial_urls_in_request(
2026-05-15T11:51:56.540472211Z                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-05-15T11:51:56.540475977Z   File "/app/aidial_adapter_openai/responses/request.py", line 114, in download_dial_urls_in_request
2026-05-15T11:51:56.540479902Z     await rule.apply(file_storage, request)
2026-05-15T11:51:56.540494845Z   File "/app/aidial_adapter_openai/responses/request.py", line 69, in apply
2026-05-15T11:51:56.540498941Z     for obj in _compile_jmespath(self.path).search(request):
2026-05-15T11:51:56.540502697Z TypeError: 'NoneType' object is not iterable
```