### PR TITLE
feat: Whisper: added audio type normalization

### DIFF
--- a/aidial_adapter_openai/audio_api/transcribe/prompt.py
+++ b/aidial_adapter_openai/audio_api/transcribe/prompt.py
@@ -68,8 +68,7 @@ class TranscribePrompt(BaseModel):
             raise RequestValidationError(message=msg, display_message=msg)
 
         audio = audios[0]
-        audio_data, audio_type = (audio.audio.data, audio.audio.type)
-        audio_type = _normalize_audio_type(audio_type)
+        audio_data, audio_type = (audio.audio.data, _normalize_audio_type(audio.audio.type))
         fileext = mimetypes.guess_extension(audio_type) or ".mp3"
         audio_filename = f"file{fileext}"
 

--- a/aidial_adapter_openai/audio_api/transcribe/prompt.py
+++ b/aidial_adapter_openai/audio_api/transcribe/prompt.py
@@ -11,14 +11,7 @@ from aidial_adapter_openai.chat_completions.transformation import (
 )
 from aidial_adapter_openai.dial_api.request import collect_message_text_content
 from aidial_adapter_openai.dial_api.storage import FileStorage
-
-
-def _normalize_audio_type(audio_type: str) -> str:
-    match audio_type.lower().strip():
-        case "audio/x-m4a" | "audio/m4a":
-            return "audio/mp4"
-        case _:
-            return audio_type
+from aidial_adapter_openai.utils.audio import normalize_audio_type
 
 
 def _collect_system_messages(messages: list[dict]) -> str | None:
@@ -68,7 +61,10 @@ class TranscribePrompt(BaseModel):
             raise RequestValidationError(message=msg, display_message=msg)
 
         audio = audios[0]
-        audio_data, audio_type = (audio.audio.data, _normalize_audio_type(audio.audio.type))
+        audio_data, audio_type = (
+            audio.audio.data,
+            normalize_audio_type(audio.audio.type),
+        )
         fileext = mimetypes.guess_extension(audio_type) or ".mp3"
         audio_filename = f"file{fileext}"
 

--- a/aidial_adapter_openai/audio_api/transcribe/prompt.py
+++ b/aidial_adapter_openai/audio_api/transcribe/prompt.py
@@ -13,6 +13,14 @@ from aidial_adapter_openai.dial_api.request import collect_message_text_content
 from aidial_adapter_openai.dial_api.storage import FileStorage
 
 
+def _normalize_audio_type(audio_type: str) -> str:
+    match audio_type.lower().strip():
+        case "audio/x-m4a" | "audio/m4a":
+            return "audio/mp4"
+        case _:
+            return audio_type
+
+
 def _collect_system_messages(messages: list[dict]) -> str | None:
     ret = ""
     for message in messages:
@@ -61,6 +69,7 @@ class TranscribePrompt(BaseModel):
 
         audio = audios[0]
         audio_data, audio_type = (audio.audio.data, audio.audio.type)
+        audio_type = _normalize_audio_type(audio_type)
         fileext = mimetypes.guess_extension(audio_type) or ".mp3"
         audio_filename = f"file{fileext}"
 

--- a/aidial_adapter_openai/utils/audio.py
+++ b/aidial_adapter_openai/utils/audio.py
@@ -1,0 +1,6 @@
+def normalize_audio_type(audio_type: str) -> str:
+    match audio_type.lower().strip():
+        case "audio/x-m4a" | "audio/m4a":
+            return "audio/mp4"
+        case _:
+            return audio_type

--- a/tests/unit_tests/test_normalize_audio_type.py
+++ b/tests/unit_tests/test_normalize_audio_type.py
@@ -1,7 +1,7 @@
 import pytest
 
 from aidial_adapter_openai.audio_api.transcribe.prompt import (
-    _normalize_audio_type,
+    normalize_audio_type,
 )
 
 
@@ -16,4 +16,4 @@ from aidial_adapter_openai.audio_api.transcribe.prompt import (
 def test_normalize_audio_type(
     audio_type: str, expected_audio_type: str
 ) -> None:
-    assert _normalize_audio_type(audio_type) == expected_audio_type
+    assert normalize_audio_type(audio_type) == expected_audio_type

--- a/tests/unit_tests/test_transcribe_prompt.py
+++ b/tests/unit_tests/test_transcribe_prompt.py
@@ -1,0 +1,19 @@
+import pytest
+
+from aidial_adapter_openai.audio_api.transcribe.prompt import (
+    _normalize_audio_type,
+)
+
+
+@pytest.mark.parametrize(
+    ("audio_type", "expected_audio_type"),
+    [
+        ("audio/x-m4a", "audio/mp4"),
+        ("audio/m4a", "audio/mp4"),
+        ("audio/mp4", "audio/mp4"),
+    ],
+)
+def test_normalize_audio_type(
+    audio_type: str, expected_audio_type: str
+) -> None:
+    assert _normalize_audio_type(audio_type) == expected_audio_type


### PR DESCRIPTION
### Issue: Whisper transcription fails for some `.m4a` attachments

Some `.m4a` files fail in Whisper transcription flow with an “invalid file format” error.

**Root cause**
- The client can send `.m4a` attachments with MIME type `audio/x-m4a` (or `audio/m4a`).
- Provider-side transcription expects a supported MIME type like `audio/mp4` / `audio/mp4a-latm`.
- Adapter forwarded the original MIME type as-is, causing provider rejection for these aliases.

**Fix in this PR**
- Added private audio MIME normalization in `audio transcribe` prompt building.
- Mapped known `.m4a` aliases:
  - `audio/x-m4a` -> `audio/mp4`
  - `audio/m4a` -> `audio/mp4`
- Kept logic extendable via `match/case` for future mappings.

**Impact**
- Transcription requests with `.m4a` aliases are accepted by provider instead of failing.
- No behavior change for already valid MIME types.

**Validation**
- Added unit test coverage for normalization cases.
- Relevant tests pass.