### PR TITLE
fix: Responses API: open reasoning stage when delta arrives

### DIFF
--- a/aidial_adapter_openai/responses/event_handler.py
+++ b/aidial_adapter_openai/responses/event_handler.py
@@ -478,6 +478,12 @@ class EventHandler(pydantic.BaseModel):
                 item_id=stage_id, summary_index=summary_index, delta=content
             ):
                 stage_key = f"reasoning:{stage_id}:{summary_index}"
+                if stage_key not in self.stage_key_to_index:
+                    chunk = self._open_stage(
+                        name="Reasoning", stage_key=stage_key
+                    )
+                    if chunk is not None:
+                        yield chunk
                 yield self._append_to_stage(
                     stage_key=stage_key, content=content
                 )


### PR DESCRIPTION
## Summary
- fix streaming failure in `EventHandler` when reasoning summary text delta events arrive before stage-open events
- lazily open a reasoning stage in `ResponseReasoningSummaryTextDeltaEvent` when the stage key is missing
- keep existing stage lifecycle behavior unchanged for normal event order

## Root Cause
`ResponseReasoningSummaryTextDeltaEvent` could be received before `ResponseReasoningSummaryPartAddedEvent`.  
In that ordering, `_append_to_stage()` attempted to resolve a non-existent stage key and raised `Stage index not found.`

## Fix
- updated reasoning delta handling to:
  - check whether `stage_key` is already present
  - call `_open_stage(name="Reasoning", stage_key=...)` when missing
  - emit the opening chunk (if created) before appending delta content

## Validation
- reproduced the issue with real streaming input and runtime instrumentation
- confirmed initial failure path: delta arrived with empty stage map
- confirmed post-fix behavior: missing stage is opened on first delta, no stage resolution exception
- removed temporary debug instrumentation after successful verification

## Impact
- prevents intermittent `500 runtime_error` during reasoning/tool streaming
- improves robustness to upstream event ordering differences
- no API contract changes