### PR TITLE
ci: re-use venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ POETRY_PYTHON ?= python
 PYDANTIC_V2 ?= 1
 ARGS ?=
 
+# Any non-empty CI value (even 'false' or '0') means that CI is enabled
+CI ?=
+
 .PHONY: all init_env install build serve lint format test integration_tests docker_build docker_run
 
 -include .env.dev
@@ -15,7 +18,7 @@ export
 all: build
 
 init_env:
-	$(POETRY) env use $(POETRY_PYTHON)
+	$(if $(CI),,$(POETRY) env use $(POETRY_PYTHON))
 
 install: init_env
 	$(POETRY) install

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,10 @@
+import os
+
 import nox
 
 nox.options.reuse_existing_virtualenvs = True
+if os.environ.get("CI"):
+    nox.options.default_venv_backend = "none"
 
 SRC = ["aidial_adapter_openai", "tests", "noxfile.py"]
 


### PR DESCRIPTION
CI speed-up:
- skip `poetry env use` when running in CI environment - no need to recreate the venv we already prepared in workflow script (`python_prepare` action)
- instruct **nox** to reuse the existing venv (created by **poetry**) instead of building a fresh one per session.

For local execution everything stays the same