### PR TITLE
fix: disable truncation for models that are not OpenAI Platform hosted

### DIFF
--- a/aidial_adapter_openai/chat_completions/tokenizer_factory.py
+++ b/aidial_adapter_openai/chat_completions/tokenizer_factory.py
@@ -28,6 +28,7 @@ from aidial_adapter_openai.chat_completions.vllm.tokenizer import (
 from aidial_adapter_openai.configuration.app_config import (
     ApplicationConfig,
     DeploymentAPIType,
+    Vendor,
 )
 from aidial_adapter_openai.configuration.deployment_type import (
     ChatCompletionDeploymentType as D,
@@ -126,6 +127,7 @@ async def create_request_tokenizer(
     extra_headers: dict[str, str],
     file_storage: FileStorage | None,
     api_key: str,
+    vendor: Vendor,
 ) -> RequestTokenizer:
     deployment_type = deployment.deployment_type
 
@@ -161,19 +163,19 @@ async def create_request_tokenizer(
                     f"Unexpected client for the deployment backed by Responses API - {type(client)}"
                 )
 
-            match client:
-                case AsyncAzureOpenAI() | AsyncBedrockOpenAI():
+            match vendor:
+                case Vendor.OPENAI_PLATFORM:
+                    return ResponsesRequestTokenizer(client, file_storage)
+                case Vendor.AWS | Vendor.AZURE:
                     raise ResourceNotFoundError(
                         "The tokenize and truncate_prompt endpoints are not "
                         "implemented for Responses API deployments backed by "
                         "Azure OpenAI or Amazon Bedrock."
                     )
-                case AsyncAnthropicFoundry():
+                case Vendor.VLLM:
                     raise ValueError(
-                        f"Unexpected client for Responses deployment - {type(client)}"
+                        "Unexpected vendor backed by Responses API - VLLM."
                     )
-                case AsyncOpenAI():
-                    return ResponsesRequestTokenizer(client, file_storage)
                 case _:
                     assert_never(client)
 

--- a/aidial_adapter_openai/configuration/app_config.py
+++ b/aidial_adapter_openai/configuration/app_config.py
@@ -53,6 +53,7 @@ class Vendor(StrEnum):
     AWS = "aws"
     VLLM = "vllm"
     AZURE = "azure"
+    OPENAI_PLATFORM = "openai_platform"
 
 
 class ApplicationConfig(ExtraForbidModel):
@@ -109,6 +110,12 @@ class ApplicationConfig(ExtraForbidModel):
         ]:
             if deployment_id in deployments:
                 return Vendor.VLLM
+
+        if (
+            isinstance(endpoint, OpenAIEndpoint)
+            and "api.openai.com" in endpoint.openai_base_url
+        ):
+            return Vendor.OPENAI_PLATFORM
 
         return Vendor.AZURE
 

--- a/aidial_adapter_openai/endpoints/chat_completion.py
+++ b/aidial_adapter_openai/endpoints/chat_completion.py
@@ -147,6 +147,7 @@ async def call_chat_completion(
                 request=request_body,
                 client=client,
                 file_storage=file_storage,
+                vendor=vendor,
             )
 
         case D.AZURE_VIDEO_API:

--- a/aidial_adapter_openai/endpoints/tokenize.py
+++ b/aidial_adapter_openai/endpoints/tokenize.py
@@ -69,7 +69,7 @@ async def tokenize(deployment_id: str, request: Request) -> TokenizeResponse:
     deployment = app_config.get_chat_completion_deployment_type(
         deployment_id, upstream_endpoint
     )
-
+    vendor = app_config.get_vendor(deployment_id, deployment.endpoint)
     extra_headers = get_upstream_extra_headers(request.headers)
     file_storage = create_file_storage(request.headers)
 
@@ -82,6 +82,7 @@ async def tokenize(deployment_id: str, request: Request) -> TokenizeResponse:
         extra_headers=extra_headers,
         file_storage=file_storage,
         api_key=tokenize_request.api_key,
+        vendor=vendor,
     )
 
     outputs: list[TokenizeOutput] = []

--- a/aidial_adapter_openai/endpoints/truncate_prompt.py
+++ b/aidial_adapter_openai/endpoints/truncate_prompt.py
@@ -177,6 +177,7 @@ async def truncate_prompt(
             | D.VLLM_CHAT_COMPLETIONS_API
             | D.QWEN3_ASR_VLLM_CHAT_COMPLETIONS_API
         ):
+            vendor = app_config.get_vendor(deployment_id, deployment.endpoint)
             tokenizer = await create_request_tokenizer(
                 request=request,
                 deployment_id=deployment_id,
@@ -186,6 +187,7 @@ async def truncate_prompt(
                 extra_headers=extra_headers,
                 file_storage=file_storage,
                 api_key=truncate_prompt_request.api_key,
+                vendor=vendor,
             )
             truncator = _RequestTokenizerTruncator(tokenizer=tokenizer)
         case _ as not_implemented:

--- a/aidial_adapter_openai/responses/adapter.py
+++ b/aidial_adapter_openai/responses/adapter.py
@@ -82,21 +82,26 @@ def _to_dict(x: BaseModel) -> dict:
 async def _truncate_prompt(
     max_prompt_tokens: int,
     request: dict[str, Any],
+    vendor: Vendor,
     client: AsyncAzureOpenAI | AsyncOpenAI | AsyncBedrockOpenAI,
     file_storage: FileStorage | None,
 ) -> DiscardedMessages | None:
-    match client:
-        case AsyncAzureOpenAI() | AsyncBedrockOpenAI():
+    match vendor:
+        case Vendor.OPENAI_PLATFORM:
+            tokenizer = ResponsesRequestTokenizer(client, file_storage)
+        case Vendor.AWS | Vendor.AZURE:
             logger.warning(
                 "max_prompt_tokens is ignored for Responses API "
                 "deployments backed by Azure OpenAI or Amazon Bedrock, "
                 "because the upstream doesn't support responses/input_tokens."
             )
             return None
-        case AsyncOpenAI():
-            tokenizer = ResponsesRequestTokenizer(client, file_storage)
+        case Vendor.VLLM:
+            raise ValueError(
+                "Unexpected vendor backed by Responses API - VLLM."
+            )
         case _:
-            assert_never(client)
+            assert_never(vendor)
 
     (
         messages,
@@ -127,12 +132,11 @@ async def chat_completion(
     _validate_request(request)
 
     discarded_messages = None
-    if (
-        max_prompt_tokens := extract_max_prompt_tokens(request)
-    ) is not None and vendor == Vendor.OPENAI_PLATFORM:
+    if (max_prompt_tokens := extract_max_prompt_tokens(request)) is not None:
         discarded_messages = await _truncate_prompt(
             max_prompt_tokens=max_prompt_tokens,
             request=request,
+            vendor=vendor,
             client=client,
             file_storage=file_storage,
         )

--- a/aidial_adapter_openai/responses/adapter.py
+++ b/aidial_adapter_openai/responses/adapter.py
@@ -12,6 +12,7 @@ from openai import (
     BaseModel,
 )
 
+from aidial_adapter_openai.configuration.app_config import Vendor
 from aidial_adapter_openai.dial_api.request import extract_max_prompt_tokens
 from aidial_adapter_openai.dial_api.storage import FileStorage
 from aidial_adapter_openai.responses.converter import (
@@ -121,11 +122,14 @@ async def chat_completion(
     request: dict[str, Any],
     client: AsyncAzureOpenAI | AsyncOpenAI | AsyncBedrockOpenAI,
     file_storage: FileStorage | None,
+    vendor: Vendor,
 ) -> AsyncIterator[dict] | dict:
     _validate_request(request)
 
     discarded_messages = None
-    if (max_prompt_tokens := extract_max_prompt_tokens(request)) is not None:
+    if (
+        max_prompt_tokens := extract_max_prompt_tokens(request)
+    ) is not None and vendor == Vendor.OPENAI_PLATFORM:
         discarded_messages = await _truncate_prompt(
             max_prompt_tokens=max_prompt_tokens,
             request=request,

--- a/aidial_adapter_openai/utils/auth.py
+++ b/aidial_adapter_openai/utils/auth.py
@@ -87,7 +87,7 @@ async def get_credentials(
             }
         case Vendor.AWS:
             return {}
-        case Vendor.VLLM:
+        case Vendor.VLLM | Vendor.OPENAI_PLATFORM:
             raise DialException(
                 "X-UPSTREAM-KEY header is missing", 401, "Unauthorized"
             )

--- a/tests/unit_tests/test_app_config.py
+++ b/tests/unit_tests/test_app_config.py
@@ -195,7 +195,7 @@ def test_get_vendor_for_generic_deployment(deployment: str):
             deployment,
             OpenAIEndpoint(openai_base_url="https://api.openai.com/v1"),
         )
-        == Vendor.AZURE
+        == Vendor.OPENAI_PLATFORM
     )
 
 

--- a/tests/unit_tests/test_responses_adapter.py
+++ b/tests/unit_tests/test_responses_adapter.py
@@ -11,8 +11,13 @@ from aidial_adapter_openai.responses.converter import (
 )
 from tests.utils.mock_server import MockServer
 
-_UPSTREAM_ENDPOINT = "http://test.api.openai.com/openai/v1/responses"
+_UPSTREAM_ENDPOINT = "https://api.openai.com/v1/responses"
 _INPUT_TOKENS_ENDPOINT = f"{_UPSTREAM_ENDPOINT}/input_tokens"
+_UNSUPPORTED_RESPONSES_UPSTREAM_ENDPOINTS = [
+    "https://test.openai.azure.com/openai/v1/responses",
+    "https://test.services.ai.azure.com/openai/v1/responses",
+    "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses",
+]
 
 
 def _response() -> Response:
@@ -28,10 +33,10 @@ def _response() -> Response:
     )
 
 
-def _headers() -> dict[str, str]:
+def _headers(upstream_endpoint: str = _UPSTREAM_ENDPOINT) -> dict[str, str]:
     return {
         "X-UPSTREAM-KEY": "test-api-key",
-        "X-UPSTREAM-ENDPOINT": _UPSTREAM_ENDPOINT,
+        "X-UPSTREAM-ENDPOINT": upstream_endpoint,
     }
 
 
@@ -122,6 +127,58 @@ async def test_max_prompt_tokens_truncates_messages(
         assert chunks[-1]["statistics"] == {"discarded_messages": [1, 2]}
     else:
         assert response.json()["statistics"] == {"discarded_messages": [1, 2]}
+
+
+@respx.mock
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize(
+    "upstream_endpoint", _UNSUPPORTED_RESPONSES_UPSTREAM_ENDPOINTS
+)
+async def test_max_prompt_tokens_ignored_for_unsupported_responses_vendor(
+    test_app: httpx.AsyncClient, stream: bool, upstream_endpoint: str
+):
+    create_bodies: list[dict[str, Any]] = []
+
+    @MockServer().post(upstream_endpoint)
+    def _create_response(request: httpx.Request):
+        create_bodies.append(json.loads(request.content))
+        return (
+            MockServer.mock_responses_api_response("text.txt")
+            if stream
+            else _response()
+        )
+
+    response = await test_app.post(
+        "/openai/deployments/adapter-deployment-name/chat/completions?api-version=2023-03-15-preview",
+        json={
+            "model": "upstream-model-name",
+            "stream": stream,
+            "max_prompt_tokens": 50,
+            "messages": [
+                {"role": "system", "content": "system message"},
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+                {"role": "user", "content": "new question"},
+            ],
+        },
+        headers=_headers(upstream_endpoint),
+    )
+
+    assert response.status_code == 200
+    assert [body["input"] for body in create_bodies] == [
+        [
+            {"role": "system", "content": "system message"},
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+            {"role": "user", "content": "new question"},
+        ]
+    ]
+
+    if stream:
+        chunks = _chat_completion_chunks(response)
+        assert "statistics" not in chunks[-1]
+    else:
+        assert "statistics" not in response.json()
 
 
 @respx.mock

--- a/tests/unit_tests/test_responses_adapter.py
+++ b/tests/unit_tests/test_responses_adapter.py
@@ -11,7 +11,7 @@ from aidial_adapter_openai.responses.converter import (
 )
 from tests.utils.mock_server import MockServer
 
-_UPSTREAM_ENDPOINT = "http://localhost:5001/openai/v1/responses"
+_UPSTREAM_ENDPOINT = "http://test.api.openai.com/openai/v1/responses"
 _INPUT_TOKENS_ENDPOINT = f"{_UPSTREAM_ENDPOINT}/input_tokens"
 
 

--- a/tests/unit_tests/test_tokenize_endpoint.py
+++ b/tests/unit_tests/test_tokenize_endpoint.py
@@ -12,9 +12,16 @@ from tests.conftest import create_test_client
 
 _UPSTREAM_ENDPOINT = "http://localhost:5001/v1/chat/completions"
 _TOKENIZE_URL = "http://localhost:5001/tokenize"
-_RESPONSES_UPSTREAM_ENDPOINT = "http://localhost:5001/openai/v1/responses"
-_RESPONSES_INPUT_TOKENS_URL = (
-    "http://localhost:5001/openai/v1/responses/input_tokens"
+_RESPONSES_UPSTREAM_ENDPOINT = "https://api.openai.com/v1/responses"
+_RESPONSES_INPUT_TOKENS_URL = f"{_RESPONSES_UPSTREAM_ENDPOINT}/input_tokens"
+_UNSUPPORTED_RESPONSES_UPSTREAM_ENDPOINTS = [
+    "https://test.openai.azure.com/openai/v1/responses",
+    "https://test.services.ai.azure.com/openai/v1/responses",
+    "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses",
+]
+_UNSUPPORTED_RESPONSES_VENDOR_ERROR_MESSAGE = (
+    "The tokenize and truncate_prompt endpoints are not implemented for "
+    "Responses API deployments backed by Azure OpenAI or Amazon Bedrock."
 )
 _API_KEY = "test-adapter-api-key"
 _RESPONSES_TOKENIZE_HEADERS = {
@@ -470,3 +477,30 @@ async def test_tokenize_to_responses_request_input(
     assert response.json() == {
         "outputs": [{"status": "success", "token_count": input_tokens}],
     }
+
+
+@pytest.mark.parametrize(
+    "upstream_endpoint", _UNSUPPORTED_RESPONSES_UPSTREAM_ENDPOINTS
+)
+@pytest.mark.asyncio
+async def test_tokenize_to_unsupported_responses_vendor_returns_404(
+    responses_client: httpx.AsyncClient,
+    upstream_endpoint: str,
+):
+    response = await responses_client.post(
+        "tokenize",
+        json={"inputs": [{"type": "string", "value": "Hello World!"}]},
+        headers=_tokenize_headers(
+            **{
+                **_RESPONSES_TOKENIZE_HEADERS,
+                "X-UPSTREAM-ENDPOINT": upstream_endpoint,
+            }
+        ),
+        params=_RESPONSES_TOKENIZE_PARAMS,
+    )
+
+    assert response.status_code == 404
+    assert (
+        response.json()["error"]["message"]
+        == _UNSUPPORTED_RESPONSES_VENDOR_ERROR_MESSAGE
+    )

--- a/tests/unit_tests/test_truncate_prompt_endpoint.py
+++ b/tests/unit_tests/test_truncate_prompt_endpoint.py
@@ -18,6 +18,15 @@ _DALLE_UPSTREAM_ENDPOINT = (
     "https://example.com/openai/deployments/dalle-test/images/generations"
 )
 _ANTHROPIC_UPSTREAM_ENDPOINT = "https://example.com/anthropic/v1/messages"
+_UNSUPPORTED_RESPONSES_UPSTREAM_ENDPOINTS = [
+    "https://test.openai.azure.com/openai/v1/responses",
+    "https://test.services.ai.azure.com/openai/v1/responses",
+    "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses",
+]
+_UNSUPPORTED_RESPONSES_VENDOR_ERROR_MESSAGE = (
+    "The tokenize and truncate_prompt endpoints are not implemented for "
+    "Responses API deployments backed by Azure OpenAI or Amazon Bedrock."
+)
 
 # "this is four tokens" -> 4 content tokens + 3 per-message + 1 role = 8 tokens.
 # The empty request base costs 3 tokens (TOKENS_PER_REQUEST).
@@ -180,6 +189,38 @@ async def test_truncate_prompt_unsupported_deployment_returns_404(
     assert response.status_code == 404
     assert response.json()["error"]["message"] == (
         "The truncate_prompt endpoint is not implemented for this deployment: DALLE3"
+    )
+
+
+@pytest.mark.parametrize(
+    "upstream_endpoint", _UNSUPPORTED_RESPONSES_UPSTREAM_ENDPOINTS
+)
+@pytest.mark.asyncio
+async def test_truncate_prompt_to_unsupported_responses_vendor_returns_404(
+    gpt_client: httpx.AsyncClient,
+    upstream_endpoint: str,
+):
+    response = await gpt_client.post(
+        "truncate_prompt",
+        json={
+            "inputs": [
+                {
+                    "max_prompt_tokens": 100,
+                    "messages": [{"role": "user", "content": "Hello"}],
+                }
+            ]
+        },
+        headers={
+            **_headers(upstream_endpoint),
+            "X-UPSTREAM-KEY": "dummy",
+        },
+        params={"api-version": "2025-01-01"},
+    )
+
+    assert response.status_code == 404
+    assert (
+        response.json()["error"]["message"]
+        == _UNSUPPORTED_RESPONSES_VENDOR_ERROR_MESSAGE
     )
 
 


### PR DESCRIPTION
## Summary
Adds Azure Responses API endpoint parsing for next-generation Azure-hosted `/openai/v1/responses` URLs, including both `openai.azure.com` and Foundry `ai.azure.com` host formats, while preserving generic OpenAI-compatible v1 fallback behavior.