### PR TITLE
feat: report Anthropic-style cache-write tokens in cache_write_tokens

### DIFF
--- a/aidial_adapter_openai/chat_completions/cache_tokens.py
+++ b/aidial_adapter_openai/chat_completions/cache_tokens.py
@@ -1,0 +1,36 @@
+"""
+Alibaba Model Studio (Qwen) reports cache-write tokens in
+`usage.prompt_tokens_details.cache_creation_input_tokens` - a field borrowed
+from the Anthropic Messages API, which isn't a part of the Chat Completions API.
+
+The module normalizes it into `usage.prompt_tokens_details.cache_write_tokens`,
+which is what DIAL expects.
+
+https://www.alibabacloud.com/help/en/model-studio/qwen-api-via-openai-chat-completions
+"""
+
+from collections.abc import AsyncIterator
+from typing import TypeVar
+
+from aidial_adapter_openai.utils.streaming import map_stream
+
+_T = TypeVar("_T", bound=AsyncIterator[dict] | dict)
+
+
+def _transform(chunk: dict) -> dict:
+    details = (chunk.get("usage") or {}).get("prompt_tokens_details") or {}
+    anthropic_cache_write = details.get("cache_creation_input_tokens")
+
+    if anthropic_cache_write is not None:
+        details["cache_write_tokens"] = max(
+            details.get("cache_write_tokens") or 0, anthropic_cache_write
+        )
+
+    return chunk
+
+
+def normalize_cache_write_tokens(response: _T) -> _T:
+    if isinstance(response, dict):
+        return _transform(response)
+    else:
+        return map_stream(_transform, response)

--- a/aidial_adapter_openai/chat_completions/cache_tokens.py
+++ b/aidial_adapter_openai/chat_completions/cache_tokens.py
@@ -17,7 +17,7 @@ _T = TypeVar("_T", bound=AsyncIterator[dict] | dict)
 
 def _transform(chunk: dict) -> dict:
     details = (chunk.get("usage") or {}).get("prompt_tokens_details") or {}
-    anthropic_cache_write = details.get("cache_creation_input_tokens")
+    anthropic_cache_write = details.pop("cache_creation_input_tokens", None)
 
     if anthropic_cache_write is not None:
         details["cache_write_tokens"] = max(

--- a/aidial_adapter_openai/chat_completions/cache_tokens.py
+++ b/aidial_adapter_openai/chat_completions/cache_tokens.py
@@ -1,12 +1,10 @@
 """
-Alibaba Model Studio (Qwen) reports cache-write tokens in
+Some models report cache-write tokens in
 `usage.prompt_tokens_details.cache_creation_input_tokens` - a field borrowed
 from the Anthropic Messages API, which isn't a part of the Chat Completions API.
 
 The module normalizes it into `usage.prompt_tokens_details.cache_write_tokens`,
 which is what DIAL expects.
-
-https://www.alibabacloud.com/help/en/model-studio/qwen-api-via-openai-chat-completions
 """
 
 from collections.abc import AsyncIterator

--- a/aidial_adapter_openai/endpoints/chat_completion.py
+++ b/aidial_adapter_openai/endpoints/chat_completion.py
@@ -15,6 +15,9 @@ from aidial_adapter_openai.audio_api.transcribe.adapter import (
 from aidial_adapter_openai.chat_completions.anthropic import (
     chat_completion as anthropic_chat_completions,
 )
+from aidial_adapter_openai.chat_completions.cache_tokens import (
+    normalize_cache_write_tokens,
+)
 from aidial_adapter_openai.chat_completions.gpt import (
     chat_completion as gpt_chat_completion,
 )
@@ -264,6 +267,7 @@ async def call_chat_completion(
 
             response.body = extract_reasoning_tokens(response.body)
             response.body = extract_audio_content(response.body, request_body)
+            response.body = normalize_cache_write_tokens(response.body)
 
             return response
 

--- a/tests/unit_tests/test_cache_tokens.py
+++ b/tests/unit_tests/test_cache_tokens.py
@@ -1,0 +1,65 @@
+from collections.abc import AsyncIterator
+
+import pytest
+
+from aidial_adapter_openai.chat_completions.cache_tokens import (
+    normalize_cache_write_tokens,
+)
+
+
+def _response(prompt_tokens_details: dict | None) -> dict:
+    usage: dict = {"prompt_tokens": 10042, "completion_tokens": 36}
+    if prompt_tokens_details is not None:
+        usage["prompt_tokens_details"] = prompt_tokens_details
+    return {"id": "chatcmpl-test", "choices": [], "usage": usage}
+
+
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        # Alibaba-style cache-write tokens are normalized
+        (
+            {"cached_tokens": 0, "cache_creation_input_tokens": 10027},
+            {
+                "cached_tokens": 0,
+                "cache_creation_input_tokens": 10027,
+                "cache_write_tokens": 10027,
+            },
+        ),
+        # The greater of the two is reported
+        (
+            {"cache_creation_input_tokens": 10027, "cache_write_tokens": 3},
+            {"cache_creation_input_tokens": 10027, "cache_write_tokens": 10027},
+        ),
+        (
+            {"cache_creation_input_tokens": 3, "cache_write_tokens": 10027},
+            {"cache_creation_input_tokens": 3, "cache_write_tokens": 10027},
+        ),
+        # Untouched when the Anthropic field is missing
+        ({"cached_tokens": 5}, {"cached_tokens": 5}),
+        ({}, {}),
+        (None, None),
+    ],
+)
+def test_block_response(given: dict | None, expected: dict | None):
+    response = normalize_cache_write_tokens(_response(given))
+    assert response == _response(expected)
+
+
+@pytest.mark.asyncio
+async def test_stream():
+    async def stream() -> AsyncIterator[dict]:
+        yield {"id": "chatcmpl-test", "choices": [{"index": 0}]}
+        yield _response({"cache_creation_input_tokens": 10027})
+
+    chunks = [chunk async for chunk in normalize_cache_write_tokens(stream())]
+
+    assert chunks == [
+        {"id": "chatcmpl-test", "choices": [{"index": 0}]},
+        _response(
+            {
+                "cache_creation_input_tokens": 10027,
+                "cache_write_tokens": 10027,
+            }
+        ),
+    ]

--- a/tests/unit_tests/test_cache_tokens.py
+++ b/tests/unit_tests/test_cache_tokens.py
@@ -17,23 +17,19 @@ def _response(prompt_tokens_details: dict | None) -> dict:
 @pytest.mark.parametrize(
     "given,expected",
     [
-        # Anthropic-style cache-write tokens are normalized
+        # Anthropic-style cache-write tokens are moved
         (
             {"cached_tokens": 0, "cache_creation_input_tokens": 10027},
-            {
-                "cached_tokens": 0,
-                "cache_creation_input_tokens": 10027,
-                "cache_write_tokens": 10027,
-            },
+            {"cached_tokens": 0, "cache_write_tokens": 10027},
         ),
         # The greater of the two is reported
         (
             {"cache_creation_input_tokens": 10027, "cache_write_tokens": 3},
-            {"cache_creation_input_tokens": 10027, "cache_write_tokens": 10027},
+            {"cache_write_tokens": 10027},
         ),
         (
             {"cache_creation_input_tokens": 3, "cache_write_tokens": 10027},
-            {"cache_creation_input_tokens": 3, "cache_write_tokens": 10027},
+            {"cache_write_tokens": 10027},
         ),
         # Untouched when the Anthropic field is missing
         ({"cached_tokens": 5}, {"cached_tokens": 5}),
@@ -56,10 +52,5 @@ async def test_stream():
 
     assert chunks == [
         {"id": "chatcmpl-test", "choices": [{"index": 0}]},
-        _response(
-            {
-                "cache_creation_input_tokens": 10027,
-                "cache_write_tokens": 10027,
-            }
-        ),
+        _response({"cache_write_tokens": 10027}),
     ]

--- a/tests/unit_tests/test_cache_tokens.py
+++ b/tests/unit_tests/test_cache_tokens.py
@@ -17,7 +17,7 @@ def _response(prompt_tokens_details: dict | None) -> dict:
 @pytest.mark.parametrize(
     "given,expected",
     [
-        # Alibaba-style cache-write tokens are normalized
+        # Anthropic-style cache-write tokens are normalized
         (
             {"cached_tokens": 0, "cache_creation_input_tokens": 10027},
             {


### PR DESCRIPTION
Some models (e.g. [Alibaba's Qwen](https://www.alibabacloud.com/help/en/model-studio/qwen-api-via-openai-chat-completions#cd3063363egdc)) report cache-write tokens in `usage.prompt_tokens_details.cache_creation_input_tokens` — an Anthropic Messages API field that isn't part of the Chat Completions API, so DIAL doesn't pick it up.

The new transformer moves it into `usage.prompt_tokens_details.cache_write_tokens` (taking the max of the two, if both are present) for block and streaming responses alike, and is wired into the generic GPT branch of `call_chat_completion` alongside the existing reasoning/audio transformers.