### PR TITLE
feat: Anthropic passthough: support Claude Platform and third-party Anthropic API providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,9 +840,11 @@ You can connect the [Qwen3-ASR](https://docs.vllm.ai/projects/recipes/en/latest/
 
 #### Anthropic Messages API
 
-The adapter supports Claude models deployed in Azure Foundry and exposing Anthropic Messages API:
+The adapter supports models exposing the Anthropic Messages API — Claude models deployed in Azure AI Foundry as well as third-party providers of the same API, e.g. [Anthropic](https://platform.claude.com/docs/en/api/messages), [Fireworks](https://docs.fireworks.ai/ecosystem/firerouter/quickstart#anthropic-messages) or [OpenRouter](https://openrouter.ai/docs/api/api-reference/anthropic-messages/create-a-message).
 
-<details><summary>DIAL Core Config</summary>
+<details><summary>DIAL Core Config for Azure AI Foundry</summary>
+
+When the API key missing, the adapter falls back to Azure Entra ID authentication.
 
 ```json
 {
@@ -855,6 +857,28 @@ The adapter supports Claude models deployed in Azure Foundry and exposing Anthro
         {
           "endpoint": "https://${AZURE_AI_FOUNDRY_SERVICE_NAME}.services.ai.azure.com/anthropic/v1/messages",
           "key": "${OPTIONAL_API_KEY}"
+        }
+      ]
+    }
+  }
+}
+```
+
+</details>
+
+<details><summary>DIAL Core Config for Anthropic Platform or a third-party Messages API provider</summary>
+
+```json
+{
+  "models": {
+    "${DIAL_DEPLOYMENT_ID}": {
+      "type": "chat",
+      "overrideName": "${ANTHROPIC_MODEL_NAME}",
+      "endpoint": "${ADAPTER_ORIGIN}/openai/deployments/${ADAPTER_DEPLOYMENT_ID}/chat/completions",
+      "upstreams": [
+        {
+          "endpoint": "https://api.anthropic.com/v1/messages",
+          "key": "${API_KEY}"
         }
       ]
     }
@@ -973,11 +997,61 @@ Set the feature flag `cacheSupported: true` in the DIAL Core configuration, when
 
 ### Anthropic API Passthrough
 
-In addition to the DIAL chat completions protocol, the adapter exposes the native [Anthropic Messages API](https://platform.claude.com/docs/en/api/messages) as a transparent passthrough mounted at `/anthropic`. Requests are forwarded to the upstream Anthropic (Azure AI Foundry) endpoint through the Anthropic SDK, so responses — including streaming — are relayed as-is.
+In addition to the DIAL chat completions protocol, the adapter exposes the native [Anthropic Messages API](https://platform.claude.com/docs/en/api/messages) as a transparent passthrough mounted at `/anthropic`. The proxied endpoints, the error schema and the client compatibility are documented in the [Anthropic adapter README](https://github.com/epam/ai-dial-adapter-anthropic/blob/0.16.0/README.md#anthropic-api).
 
-The passthrough itself — the list of the proxied endpoints, the error schema and the client compatibility — is documented in the [Anthropic adapter README](https://github.com/epam/ai-dial-adapter-anthropic/blob/0.16.0/README.md#anthropic-api).
+A DIAL deployment becomes callable via the Messages API once the [anthropicMessages interface](https://github.com/epam/ai-dial-core/blob/development/docs/dynamic-settings/models.md#modelsmodel_nameinterfaces) is declared for it in the DIAL Core config. The upstream endpoint is resolved by the same rules as for [chat completions](#anthropic-messages-api): Azure AI Foundry or any other provider of the Messages API.
 
-The adapter is a pure proxy: it takes the upstream endpoint and key from the `X-UPSTREAM-ENDPOINT` and `X-UPSTREAM-KEY` request headers, which DIAL Core injects when routing to the adapter. When calling the adapter directly, these headers must be supplied by the caller.
+<details><summary>DIAL Core Config for Azure AI Foundry</summary>
+
+```json
+{
+  "models": {
+    "${DIAL_DEPLOYMENT_ID}": {
+      "type": "chat",
+      "overrideName": "${ANTHROPIC_MODEL_NAME}",
+      "interfaces": {
+        "anthropicMessages": {
+          "base_url": "${ADAPTER_ORIGIN}"
+        }
+      },
+      "upstreams": [
+        {
+          "endpoint": "https://${AZURE_AI_FOUNDRY_SERVICE_NAME}.services.ai.azure.com/anthropic/v1/messages",
+          "key": "${OPTIONAL_API_KEY}"
+        }
+      ]
+    }
+  }
+}
+```
+
+</details>
+
+<details><summary>DIAL Core Config for Anthropic Platform or a third-party Messages API provider</summary>
+
+```json
+{
+  "models": {
+    "${DIAL_DEPLOYMENT_ID}": {
+      "type": "chat",
+      "overrideName": "${ANTHROPIC_MODEL_NAME}",
+      "interfaces": {
+        "anthropicMessages": {
+          "base_url": "${ADAPTER_ORIGIN}"
+        }
+      },
+      "upstreams": [
+        {
+          "endpoint": "https://api.anthropic.com/v1/messages",
+          "key": "${API_KEY}"
+        }
+      ]
+    }
+  }
+}
+```
+
+</details>
 
 #### Using Claude Code with the adapter
 

--- a/aidial_adapter_openai/chat_completions/anthropic.py
+++ b/aidial_adapter_openai/chat_completions/anthropic.py
@@ -9,7 +9,7 @@ from aidial_adapter_anthropic.dial.request import ModelParameters
 from aidial_adapter_anthropic.dial.storage import FileStorage
 from aidial_sdk.chat_completion import Request as DIALRequest
 from aidial_sdk.chat_completion import Response as DIALResponse
-from anthropic import AsyncAnthropicFoundry
+from anthropic import AsyncAnthropic
 from fastapi.responses import StreamingResponse
 
 from aidial_adapter_openai.dial_api.sdk_adapter import sdk_adapter
@@ -27,7 +27,7 @@ def _create_file_storage(api_key: str | None) -> FileStorage | None:
 
 
 async def create_adapter(
-    deployment: str, api_key: str, client: AsyncAnthropicFoundry
+    deployment: str, api_key: str, client: AsyncAnthropic
 ) -> ChatCompletionAdapter:
     return await create_anthropic_adapter(
         deployment=deployment,
@@ -44,7 +44,7 @@ async def chat_completion(
     *,
     request: fastapi.Request,
     deployment_id: str,
-    client: AsyncAnthropicFoundry,
+    client: AsyncAnthropic,
 ) -> StreamingResponse | dict:
     async def _handler(request: DIALRequest, response: DIALResponse) -> None:
         model = await create_adapter(deployment_id, request.api_key, client)

--- a/aidial_adapter_openai/chat_completions/anthropic_passthrough.py
+++ b/aidial_adapter_openai/chat_completions/anthropic_passthrough.py
@@ -1,6 +1,6 @@
 import fastapi
 from aidial_adapter_anthropic.passthrough import mount_anthropic_api
-from anthropic import AsyncAnthropicFoundry
+from anthropic import AsyncAnthropic, AsyncAnthropicFoundry
 
 from aidial_adapter_openai.configuration.app_config import (
     Vendor,
@@ -14,15 +14,18 @@ from aidial_adapter_openai.utils.parsers import (
 
 
 def _strip_unsupported_features(
-    client: AsyncAnthropicFoundry, features: list[str]
+    client: AsyncAnthropic, features: list[str]
 ) -> list[str]:
-    _unsupported_flags_by_azure = {"advisor-tool-2026-03-01"}
-    return [f for f in features if f not in _unsupported_flags_by_azure]
+    if isinstance(client, AsyncAnthropicFoundry):
+        _unsupported_flags_by_azure = {"advisor-tool-2026-03-01"}
+        return [f for f in features if f not in _unsupported_flags_by_azure]
+
+    return features
 
 
 async def _get_anthropic_client(
     request: fastapi.Request,
-) -> AsyncAnthropicFoundry:
+) -> AsyncAnthropic:
     headers = request.headers
     upstream_endpoint = get_upstream_endpoint(headers)
 

--- a/aidial_adapter_openai/chat_completions/tokenizer_factory.py
+++ b/aidial_adapter_openai/chat_completions/tokenizer_factory.py
@@ -11,7 +11,7 @@ from aidial_adapter_anthropic.adapter import ChatCompletionAdapter
 from aidial_adapter_anthropic.dial.request import ModelParameters
 from aidial_sdk.chat_completion.request import ChatCompletionRequest
 from aidial_sdk.exceptions import ResourceNotFoundError
-from anthropic import AsyncAnthropicFoundry
+from anthropic import AsyncAnthropic
 from fastapi import Request
 from openai import AsyncAzureOpenAI, AsyncBedrockOpenAI, AsyncOpenAI
 
@@ -188,7 +188,7 @@ async def create_request_tokenizer(
                 extra_headers=extra_headers,
                 api_version=get_api_version(request),
             )
-            if not isinstance(client, AsyncAnthropicFoundry):
+            if not isinstance(client, AsyncAnthropic):
                 raise ValueError(
                     f"Unexpected client for Anthropic deployment - {type(client)}"
                 )

--- a/aidial_adapter_openai/endpoints/chat_completion.py
+++ b/aidial_adapter_openai/endpoints/chat_completion.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping
 from typing import assert_never
 
 import fastapi
-from anthropic import AsyncAnthropicFoundry
+from anthropic import AsyncAnthropic
 from fastapi import Request
 from openai import AsyncAzureOpenAI
 
@@ -128,7 +128,7 @@ async def call_chat_completion(
             app_config, deployment_id, deployment_type
         )
 
-    if isinstance(client, AsyncAnthropicFoundry):
+    if isinstance(client, AsyncAnthropic):
         return await anthropic_chat_completions(
             request=request,
             client=client,

--- a/aidial_adapter_openai/endpoints/truncate_prompt.py
+++ b/aidial_adapter_openai/endpoints/truncate_prompt.py
@@ -12,7 +12,7 @@ from aidial_sdk.deployment.truncate_prompt import (
     TruncatePromptSuccess,
 )
 from aidial_sdk.exceptions import RequestValidationError, ResourceNotFoundError
-from anthropic import AsyncAnthropicFoundry
+from anthropic import AsyncAnthropic
 from fastapi import Request
 from pydantic import ValidationError
 
@@ -157,7 +157,7 @@ async def truncate_prompt(
                 extra_headers=extra_headers,
                 api_version=get_api_version(request),
             )
-            if not isinstance(client, AsyncAnthropicFoundry):
+            if not isinstance(client, AsyncAnthropic):
                 raise ValueError(
                     f"Unexpected client for Anthropic deployment - {type(client)}"
                 )

--- a/aidial_adapter_openai/utils/client.py
+++ b/aidial_adapter_openai/utils/client.py
@@ -1,4 +1,4 @@
-from anthropic import AsyncAnthropicFoundry
+from anthropic import AsyncAnthropic
 from fastapi import Request
 from openai import AsyncAzureOpenAI, AsyncBedrockOpenAI, AsyncOpenAI
 
@@ -8,9 +8,7 @@ from aidial_adapter_openai.configuration.app_config import (
 )
 from aidial_adapter_openai.utils.auth import get_credentials
 
-_Client = (
-    AsyncAzureOpenAI | AsyncBedrockOpenAI | AsyncOpenAI | AsyncAnthropicFoundry
-)
+_Client = AsyncAzureOpenAI | AsyncBedrockOpenAI | AsyncOpenAI | AsyncAnthropic
 
 
 async def get_client(

--- a/aidial_adapter_openai/utils/parsers.py
+++ b/aidial_adapter_openai/utils/parsers.py
@@ -3,9 +3,10 @@ from collections.abc import Callable
 from http import HTTPStatus
 from json import JSONDecodeError
 from typing import Any
+from urllib.parse import urlparse
 
 from aidial_sdk.exceptions import HTTPException, InvalidRequestError
-from anthropic import AsyncAnthropicFoundry
+from anthropic import AsyncAnthropic, AsyncAnthropicFoundry
 from aws_bedrock_token_generator import provide_token
 from fastapi import Request
 from openai import AsyncAzureOpenAI, AsyncBedrockOpenAI, AsyncOpenAI
@@ -66,8 +67,20 @@ class OpenAIEndpoint(ExtraForbidModel):
 
 class AnthropicEndpoint(ExtraForbidModel):
     anthropic_base_url: str
+    # Azure AI Foundry endpoints require Azure-specific authentication,
+    # while other providers of the Messages API (Anthropic itself,
+    # Fireworks, OpenRouter etc) are served by the vanilla client.
+    foundry: bool
 
-    def get_client(self, params: OpenAIParams) -> AsyncAnthropicFoundry:
+    def get_client(self, params: OpenAIParams) -> AsyncAnthropic:
+        if not self.foundry:
+            return AsyncAnthropic(
+                base_url=self.anthropic_base_url,
+                api_key=params.get("api_key"),
+                max_retries=_MAX_RETRIES,
+                http_client=get_anthropic_httpx_client(),
+            )
+
         if (token := params.get("azure_ad_token")) is not None:
 
             def _provider():
@@ -181,10 +194,18 @@ class CompletionsParser(ExtraForbidModel):
 
 
 class AnthropicEndpointParser:
+    @staticmethod
+    def _is_foundry_base_url(base_url: str) -> bool:
+        hostname = urlparse(base_url).hostname or ""
+        return "azure" in hostname and base_url.endswith("/anthropic")
+
     def try_parse(self, endpoint: str) -> AnthropicEndpoint | None:
-        if match := re.match(r"(.*/anthropic)/v1/messages", endpoint):
+        if match := re.match(r"(.*?)/v1/messages", endpoint):
             base_url = match.group(1)
-            return AnthropicEndpoint(anthropic_base_url=base_url)
+            return AnthropicEndpoint(
+                anthropic_base_url=base_url,
+                foundry=self._is_foundry_base_url(base_url),
+            )
         return None
 
 

--- a/tests/unit_tests/test_anthropic_chat_completion.py
+++ b/tests/unit_tests/test_anthropic_chat_completion.py
@@ -12,29 +12,15 @@ _FIREWORKS_BASE = "https://api.fireworks.ai/inference"
 _OPENROUTER_BASE = "https://openrouter.ai/api"
 _UPSTREAM_KEY = "test-upstream-key"
 
-_MESSAGES_REQUEST = {
-    "model": "claude-opus-4-5",
-    "messages": [{"role": "user", "content": "Say hello."}],
-    "max_tokens": 1024,
-}
-
 _MESSAGES_RESPONSE = {
     "id": "msg_123",
     "type": "message",
     "role": "assistant",
-    "content": [{"type": "text", "text": "Hello! How can I assist you today?"}],
+    "content": [{"type": "text", "text": "Hello!"}],
     "model": "claude-opus-4-5",
     "stop_reason": "end_turn",
-    "usage": {"input_tokens": 10, "output_tokens": 9},
+    "usage": {"input_tokens": 10, "output_tokens": 3},
 }
-
-
-def _headers(upstream_base: str, **extra: str) -> dict[str, str]:
-    return {
-        "X-UPSTREAM-ENDPOINT": f"{upstream_base}/v1/messages",
-        "X-UPSTREAM-KEY": _UPSTREAM_KEY,
-        **extra,
-    }
 
 
 @pytest.mark.parametrize(
@@ -50,10 +36,10 @@ def _headers(upstream_base: str, **extra: str) -> dict[str, str]:
     ],
 )
 @respx.mock
-async def test_messages_passthrough_relays_upstream_response(
+async def test_dial_chat_completion_via_messages_api(
     upstream_base: str, auth_header: str
 ):
-    route = respx.post(url__regex=rf"{upstream_base}/v1/messages.*").respond(
+    route = respx.post(f"{upstream_base}/v1/messages").respond(
         status_code=200,
         content_type="application/json",
         content=json.dumps(_MESSAGES_RESPONSE),
@@ -61,16 +47,22 @@ async def test_messages_passthrough_relays_upstream_response(
 
     async with create_test_client(ApplicationConfig()) as client:
         response = await client.post(
-            "/anthropic/v1/messages",
-            json=_MESSAGES_REQUEST,
-            headers=_headers(upstream_base),
+            "/openai/deployments/claude-opus-4-5/chat/completions"
+            "?api-version=2024-12-01-preview",
+            json={"messages": [{"role": "user", "content": "Say hello."}]},
+            headers={
+                "X-UPSTREAM-ENDPOINT": f"{upstream_base}/v1/messages",
+                "X-UPSTREAM-KEY": _UPSTREAM_KEY,
+                "Api-Key": "test-adapter-key",
+            },
         )
 
-    assert response.status_code == 200
-    assert response.json() == _MESSAGES_RESPONSE
-    assert route.called
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["choices"][0]["message"]["content"] == "Hello!"
+    assert body["usage"]["prompt_tokens"] == 10
+    assert body["usage"]["completion_tokens"] == 3
 
-    # The upstream must receive the request body unchanged.
+    assert route.called
     upstream_request = route.calls.last.request
-    assert json.loads(upstream_request.content) == _MESSAGES_REQUEST
     assert upstream_request.headers[auth_header] == _UPSTREAM_KEY

--- a/tests/unit_tests/test_app_config.py
+++ b/tests/unit_tests/test_app_config.py
@@ -9,6 +9,7 @@ from aidial_adapter_openai.configuration.deployment_type import (
     ChatCompletionDeploymentType as D,
 )
 from aidial_adapter_openai.utils.parsers import (
+    AnthropicEndpoint,
     AzureOpenAIEndpoint,
     BedrockOpenAIEndpoint,
     OpenAIEndpoint,
@@ -186,6 +187,53 @@ def test_app_config_qwen3_asr_vllm_deployments(origin: str, deployment: str):
     )
 
     assert ty.deployment_type == D.QWEN3_ASR_VLLM_CHAT_COMPLETIONS_API
+
+
+@pytest.mark.parametrize(
+    ("upstream_endpoint", "base_url", "foundry"),
+    [
+        (
+            "https://test.services.ai.azure.com/anthropic/v1/messages",
+            "https://test.services.ai.azure.com/anthropic",
+            True,
+        ),
+        (
+            "https://api.fireworks.ai/inference/v1/messages",
+            "https://api.fireworks.ai/inference",
+            False,
+        ),
+        (
+            "https://api.anthropic.com/v1/messages",
+            "https://api.anthropic.com",
+            False,
+        ),
+        (
+            "https://openrouter.ai/api/v1/messages",
+            "https://openrouter.ai/api",
+            False,
+        ),
+        # The /anthropic path alone doesn't make it an Azure Foundry endpoint.
+        (
+            "https://gateway.example.com/anthropic/v1/messages",
+            "https://gateway.example.com/anthropic",
+            False,
+        ),
+    ],
+)
+def test_app_config_anthropic_messages(
+    deployment: str,
+    upstream_endpoint: str,
+    base_url: str,
+    foundry: bool,
+):
+    cfg = ApplicationConfig()
+    ty = cfg.get_chat_completion_deployment_type(deployment, upstream_endpoint)
+
+    assert ty.deployment_type == D.ANTHROPIC_MESSAGES_API
+    endpoint = ty.endpoint
+    assert isinstance(endpoint, AnthropicEndpoint)
+    assert endpoint.anthropic_base_url == base_url
+    assert endpoint.foundry == foundry
 
 
 def test_get_vendor_for_generic_deployment(deployment: str):


### PR DESCRIPTION
Backward-compatible extension of the upstreams accepted by the Anthropic Messages API endpoints (both passthrough mode and chat completions adapter).

**Accepted upstream endpoints**

|Provider|Upstream endpoint|Before|Now|Auth header|
|---|---|---|---|---|
|[Azure Foundry](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/how-to/use-foundry-models-claude)|`https://${resource}.services.ai.azure.com/anthropic/v1/messages`|✅|✅|`api-key`, Entra ID fallback|
|[Claude Platform](https://platform.claude.com/docs/en/api/messages)|`https://api.anthropic.com/v1/messages`|❌|✅|`x-api-key`|
|[Fireworks](https://docs.fireworks.ai/api-reference/anthropic-messages)|`https://api.fireworks.ai/inference/v1/messages`|❌|✅|`x-api-key`|
|[OpenRouter](https://openrouter.ai/docs/api/api-reference/anthropic-messages/create-a-message)|`https://openrouter.ai/api/v1/messages`|❌|✅|`x-api-key`|