### PR TITLE
fix: Chat Completions API adapter: remove DIAL-specific fields before sending request to the upstream

### DIFF
--- a/aidial_adapter_openai/chat_completions/gpt.py
+++ b/aidial_adapter_openai/chat_completions/gpt.py
@@ -6,6 +6,9 @@ from openai.types.chat import ChatCompletion, ChatCompletionChunk
 from aidial_adapter_openai.chat_completions.transformation import (
     ResourceProcessor,
 )
+from aidial_adapter_openai.dial_api.normalize_request import (
+    normalize_dial_request,
+)
 from aidial_adapter_openai.dial_api.request import extract_max_prompt_tokens
 from aidial_adapter_openai.dial_api.storage import FileStorage
 from aidial_adapter_openai.utils.caching import get_response_headers_for_caching
@@ -100,7 +103,9 @@ async def chat_completion(
 
     response: (
         AsyncStream[ChatCompletionChunk] | ChatCompletion
-    ) = await call_with_extra_body(client.chat.completions.create, request)
+    ) = await call_with_extra_body(
+        client.chat.completions.create, normalize_dial_request(request)
+    )
 
     if isinstance(response, AsyncStream):
         response_headers = await get_response_headers_for_caching(

--- a/aidial_adapter_openai/chat_completions/mistral.py
+++ b/aidial_adapter_openai/chat_completions/mistral.py
@@ -5,6 +5,9 @@ from openai import AsyncAzureOpenAI, AsyncOpenAI, AsyncStream
 from openai.types.chat.chat_completion import ChatCompletion
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 
+from aidial_adapter_openai.dial_api.normalize_request import (
+    normalize_dial_request,
+)
 from aidial_adapter_openai.utils.log_config import logger
 from aidial_adapter_openai.utils.reflection import call_with_extra_body
 from aidial_adapter_openai.utils.streaming import map_stream
@@ -138,7 +141,9 @@ async def chat_completion(
 ) -> AsyncIterator[dict] | dict:
     response: (
         AsyncStream[ChatCompletionChunk] | ChatCompletion
-    ) = await call_with_extra_body(client.chat.completions.create, request)
+    ) = await call_with_extra_body(
+        client.chat.completions.create, normalize_dial_request(request)
+    )
 
     if isinstance(response, AsyncStream):
         raw_stream = map_stream(_response_to_dict, response)

--- a/aidial_adapter_openai/chat_completions/non_gpt.py
+++ b/aidial_adapter_openai/chat_completions/non_gpt.py
@@ -4,6 +4,9 @@ from openai import AsyncAzureOpenAI, AsyncOpenAI, AsyncStream
 from openai.types.chat.chat_completion import ChatCompletion
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 
+from aidial_adapter_openai.dial_api.normalize_request import (
+    normalize_dial_request,
+)
 from aidial_adapter_openai.utils.reflection import call_with_extra_body
 from aidial_adapter_openai.utils.streaming import chunk_to_dict, map_stream
 
@@ -13,7 +16,9 @@ async def chat_completion(
 ) -> AsyncIterator[dict] | dict:
     response: (
         AsyncStream[ChatCompletionChunk] | ChatCompletion
-    ) = await call_with_extra_body(client.chat.completions.create, request)
+    ) = await call_with_extra_body(
+        client.chat.completions.create, normalize_dial_request(request)
+    )
 
     if isinstance(response, AsyncStream):
         return map_stream(chunk_to_dict, response)

--- a/aidial_adapter_openai/chat_completions/vllm/chat_completion.py
+++ b/aidial_adapter_openai/chat_completions/vllm/chat_completion.py
@@ -12,6 +12,9 @@ from aidial_adapter_openai.chat_completions.vllm.audio_transformer import (
 from aidial_adapter_openai.chat_completions.vllm.tokenizer import (
     VllmTokenizer,
 )
+from aidial_adapter_openai.dial_api.normalize_request import (
+    normalize_dial_request,
+)
 from aidial_adapter_openai.dial_api.request import extract_max_prompt_tokens
 from aidial_adapter_openai.dial_api.storage import FileStorage
 from aidial_adapter_openai.utils.log_config import logger
@@ -115,7 +118,9 @@ async def chat_completion(
 
     response: (
         AsyncStream[ChatCompletionChunk] | ChatCompletion
-    ) = await call_with_extra_body(client.chat.completions.create, request)
+    ) = await call_with_extra_body(
+        client.chat.completions.create, normalize_dial_request(request)
+    )
 
     if isinstance(response, AsyncStream):
         body = add_statistics_to_response(

--- a/aidial_adapter_openai/dial_api/normalize_request.py
+++ b/aidial_adapter_openai/dial_api/normalize_request.py
@@ -1,0 +1,238 @@
+"""
+Normalization of a DIAL chat completion request into a plain Chat Completions
+request, which is proxied to an upstream nearly as-is.
+
+DIAL extends the Chat Completions request with a handful of fields of its own
+(see https://github.com/epam/ai-dial-sdk/). Upstreams with strict request
+validation reject unknown fields, so every such field is either translated
+into its native counterpart or dropped before proxying.
+
+The normalization is split into two independent stages:
+
+1. parsing: DIAL request -> Chat Completions request + DIAL features,
+2. absorption: Chat Completions request + DIAL features -> Chat Completions request.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from functools import wraps
+from typing import TypeVar, cast
+
+from aidial_client.types.chat import ChatCompletionRequest as DialRequest
+from aidial_client.types.chat import (
+    ChatCompletionRequestCustomFields,
+    CustomContentParam,
+    Message,
+    MessageCustomFieldsParam,
+    StaticToolParam,
+    ToolCustomFieldsParam,
+    ToolParam,
+)
+from aidial_sdk.exceptions import HTTPException as DialException
+from aidial_sdk.exceptions import InvalidRequestError
+from openai.types.chat import (
+    ChatCompletionContentPartParam,
+    ChatCompletionMessageParam,
+)
+from openai.types.chat.chat_completion_content_part_text_param import (
+    PromptCacheBreakpoint,
+)
+from openai.types.chat.completion_create_params import (
+    CompletionCreateParamsBase as ChatCompletionsRequest,
+)
+
+from aidial_adapter_openai.utils.log_config import logger
+from aidial_adapter_openai.utils.validation import ensure_dict
+
+# The native counterpart of DIAL's `cache_breakpoint`. Note that DIAL marks
+# a whole message, whereas the Chat Completions API marks an individual
+# content part and supports no mode other than "explicit".
+_PROMPT_CACHE_BREAKPOINT: PromptCacheBreakpoint = {"mode": "explicit"}
+
+_T = TypeVar("_T")
+
+
+@dataclass
+class DialFeatures:
+    """
+    The DIAL-specific fields carried by a DIAL request. The per-message and
+    per-tool ones are keyed by the index of the element they came from.
+    """
+
+    custom_fields: ChatCompletionRequestCustomFields = field(
+        default_factory=ChatCompletionRequestCustomFields
+    )
+    message_custom_content: dict[int, CustomContentParam] = field(
+        default_factory=dict
+    )
+    message_custom_fields: dict[int, MessageCustomFieldsParam] = field(
+        default_factory=dict
+    )
+    tool_custom_fields: dict[int, ToolCustomFieldsParam] = field(
+        default_factory=dict
+    )
+
+
+def _proxy_as_is_on_error(
+    normalize: Callable[[dict], dict],
+) -> Callable[[dict], dict]:
+    """
+    Guards against errors in the normalization itself: a request which failed
+    to be normalized is proxied to the upstream as-is. The request validation
+    errors are reported to the caller as usual.
+    """
+
+    @wraps(normalize)
+    def wrapper(request: dict) -> dict:
+        try:
+            return normalize(request)
+        except DialException:
+            raise
+        except Exception:
+            logger.exception("Failed to normalize the request")
+            return request
+
+    return wrapper
+
+
+@_proxy_as_is_on_error
+def normalize_dial_request(request: dict) -> dict:
+    """
+    Returns a copy of the request with the DIAL-specific fields either
+    translated into their native Chat Completions counterparts or dropped.
+    """
+    parsed, features = _parse_dial_request(request)
+    return cast(dict, _absorb_dial_features(parsed, features))
+
+
+def _parse_dial_request(
+    request: dict,
+) -> tuple[ChatCompletionsRequest, DialFeatures]:
+    parsed = cast(DialRequest, request).copy()
+    features = DialFeatures()
+
+    features.custom_fields = _ensure_dict(
+        "custom_fields", parsed.pop("custom_fields", None)
+    )
+
+    if (messages := parsed.get("messages")) is not None:
+        parsed["messages"] = [
+            _parse_message(index, message, features)
+            for index, message in enumerate(messages)
+        ]
+
+    if (tools := parsed.get("tools")) is not None:
+        parsed["tools"] = [
+            _parse_tool(index, tool, features)
+            for index, tool in enumerate(tools)
+        ]
+
+    return cast(ChatCompletionsRequest, parsed), features
+
+
+def _parse_message(
+    index: int, message: Message, features: DialFeatures
+) -> Message:
+    path = f"messages[{index}]"
+    message = _copy_dict(path, message)
+
+    if (custom_content := message.pop("custom_content", None)) is not None:
+        features.message_custom_content[index] = _ensure_dict(
+            f"{path}.custom_content", custom_content
+        )
+
+    if (custom_fields := message.pop("custom_fields", None)) is not None:
+        features.message_custom_fields[index] = _ensure_dict(
+            f"{path}.custom_fields", custom_fields
+        )
+
+    return message
+
+
+def _parse_tool(
+    index: int, tool: ToolParam | StaticToolParam, features: DialFeatures
+) -> ToolParam | StaticToolParam:
+    path = f"tools[{index}]"
+    tool = _copy_dict(path, tool)
+
+    if tool.get("type") == "static_function":
+        raise InvalidRequestError(
+            f"The upstream doesn't support DIAL static tool at {path!r}"
+        )
+
+    # `custom_fields` is only declared on a function tool, but it's taken
+    # from a tool of any shape.
+    custom_fields = cast(ToolParam, tool).pop("custom_fields", None)
+    if custom_fields is not None:
+        features.tool_custom_fields[index] = _ensure_dict(
+            f"{path}.custom_fields", custom_fields
+        )
+
+    return tool
+
+
+def _absorb_dial_features(
+    request: ChatCompletionsRequest, features: DialFeatures
+) -> ChatCompletionsRequest:
+    # The cache breakpoints are the only DIAL feature with a native
+    # counterpart in the Chat Completions API; the rest is ignored.
+    breakpoints = {
+        index
+        for index, custom_fields in features.message_custom_fields.items()
+        if custom_fields.get("cache_breakpoint") is not None
+    }
+    if not breakpoints:
+        return request
+
+    request = request.copy()
+    request["messages"] = [
+        _mark_cache_breakpoint(message) if index in breakpoints else message
+        for index, message in enumerate(request.get("messages", []))
+    ]
+
+    return request
+
+
+def _mark_cache_breakpoint(
+    message: ChatCompletionMessageParam,
+) -> ChatCompletionMessageParam:
+    """
+    Marks the end of the cacheable prefix at the last content part of the
+    message. The message is returned intact, if it has no part to mark.
+    """
+    content = message.get("content")
+    prefix: list
+
+    if isinstance(content, str) and content:
+        prefix = []
+        part: ChatCompletionContentPartParam = {"type": "text", "text": content}
+    elif isinstance(content, list) and content:
+        prefix, last = content[:-1], content[-1]
+        # A refusal part is the only one which can't carry a breakpoint.
+        if last.get("type") == "refusal":
+            return message
+        part = cast(ChatCompletionContentPartParam, dict(last))
+    else:
+        return message
+
+    part["prompt_cache_breakpoint"] = _PROMPT_CACHE_BREAKPOINT
+
+    marked = dict(message)
+    marked["content"] = [*prefix, part]
+    return cast(ChatCompletionMessageParam, marked)
+
+
+def _ensure_dict(name: str, value: _T | None) -> _T:
+    """
+    Checks that an optional request element is indeed an object.
+    A missing element is treated as an empty one.
+    """
+    return cast(_T, {} if value is None else ensure_dict(name, value))
+
+
+def _copy_dict(name: str, value: _T) -> _T:
+    """
+    Same as `_ensure_dict`, but the element is copied,
+    so that the original request is left intact.
+    """
+    return cast(_T, dict(ensure_dict(name, value)))

--- a/aidial_adapter_openai/dial_api/storage.py
+++ b/aidial_adapter_openai/dial_api/storage.py
@@ -11,7 +11,7 @@ from urllib.parse import unquote, urljoin
 import httpx
 from aidial_client import AsyncDial, DialException
 from aidial_client._exception import NotDialURLError
-from aidial_client.types.metadata import FileMetadata
+from aidial_client.types.metadata import FileItem
 from aidial_sdk.exceptions import InvalidRequestError
 
 from aidial_adapter_openai.utils.log_config import logger as log
@@ -55,7 +55,7 @@ class FileStorage:
 
     async def upload(
         self, upload_dir: str, filename: str, content_type: str, content: bytes
-    ) -> FileMetadata:
+    ) -> FileItem:
         ext = mimetypes.guess_extension(content_type) or ""
         stored_filename = f"{filename}{ext}"
         base_dir = await self._upload_base_dir()
@@ -70,7 +70,7 @@ class FileStorage:
 
     async def upload_file(
         self, upload_dir: str, data: str | bytes, content_type: str
-    ) -> FileMetadata:
+    ) -> FileItem:
         filename = _compute_hash_digest(data)
         if isinstance(data, str):
             content: bytes = base64.b64decode(data)

--- a/poetry.lock
+++ b/poetry.lock
@@ -25,14 +25,14 @@ bedrock = ["botocore (>=1.10.0)"]
 
 [[package]]
 name = "aidial-client"
-version = "0.11.0"
+version = "0.16.1"
 description = "A Python client library for the AI DIAL API"
 optional = false
 python-versions = "<3.14,>=3.10"
 groups = ["main"]
 files = [
-    {file = "aidial_client-0.11.0-py3-none-any.whl", hash = "sha256:c2b97c0e381b78811c72cbf820d1abceec7af302f3e113d6c2dc98df135b3691"},
-    {file = "aidial_client-0.11.0.tar.gz", hash = "sha256:aace045806a57343bd9600c6287cade8807a56ea31fa8bf6aaeb3b5abcb8d9a9"},
+    {file = "aidial_client-0.16.1-py3-none-any.whl", hash = "sha256:8cbc25ca28d54c19559c6f06b46ef5fa7cf4f4205bf91d6769b5fb951b51f00b"},
+    {file = "aidial_client-0.16.1.tar.gz", hash = "sha256:6dce4b6d8254727b5eb69c5343c6117dc7bb43acbae4dbaf9087571100c35d69"},
 ]
 
 [package.dependencies]
@@ -3442,4 +3442,4 @@ test = ["big-O", "importlib-resources ; python_version < \"3.9\"", "jaraco.funct
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "1d661f969e23e042effe760acec9fedbc13fe05dc90f9245d58cc3bebdc2701d"
+content-hash = "999e26696b9a1e41bc03c0f26ea437d7cffe3d97b072d299d8a453915599dc81"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ aidial-sdk = { version = "0.39.0", extras = ["telemetry"] }
 aidial-adapter-anthropic = "0.16.0"
 anthropic = "0.105.0"
 jmespath = "1.1.0"
-aidial-client = "0.11.0"
+aidial-client = "0.16.1"
 aws-bedrock-token-generator = "^1.1.0"
 
 [tool.poetry.group.test.dependencies]

--- a/tests/unit_tests/test_normalize_request.py
+++ b/tests/unit_tests/test_normalize_request.py
@@ -1,0 +1,269 @@
+import json
+
+import httpx
+import pytest
+import respx
+from aidial_sdk.exceptions import InvalidRequestError
+
+from aidial_adapter_openai.dial_api.normalize_request import (
+    DialFeatures,
+    _parse_dial_request,
+    normalize_dial_request,
+)
+from tests.utils.stream import OpenAIStream, single_choice_chunk
+
+_EXPLICIT = {"prompt_cache_breakpoint": {"mode": "explicit"}}
+
+
+def test_cache_breakpoint_on_string_content():
+    request = {
+        "messages": [
+            {
+                "role": "user",
+                "content": "hi",
+                "custom_fields": {"cache_breakpoint": {}},
+            }
+        ]
+    }
+
+    assert normalize_dial_request(request) == {
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "hi", **_EXPLICIT}],
+            }
+        ]
+    }
+
+
+def test_cache_breakpoint_marks_last_content_part():
+    request = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "a"},
+                    {"type": "text", "text": "b"},
+                ],
+                "custom_fields": {"cache_breakpoint": {"expire_at": "later"}},
+            }
+        ]
+    }
+
+    assert normalize_dial_request(request)["messages"] == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "a"},
+                {"type": "text", "text": "b", **_EXPLICIT},
+            ],
+        }
+    ]
+
+
+def test_cache_breakpoint_without_content_is_dropped():
+    request = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [],
+                "custom_fields": {"cache_breakpoint": {}},
+            }
+        ]
+    }
+
+    assert normalize_dial_request(request)["messages"] == [
+        {"role": "assistant", "content": None, "tool_calls": []}
+    ]
+
+
+def test_cache_breakpoint_on_refusal_part_is_dropped():
+    request = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [{"type": "refusal", "refusal": "no"}],
+                "custom_fields": {"cache_breakpoint": {}},
+            }
+        ]
+    }
+
+    assert normalize_dial_request(request)["messages"] == [
+        {
+            "role": "assistant",
+            "content": [{"type": "refusal", "refusal": "no"}],
+        }
+    ]
+
+
+def test_dial_fields_are_dropped():
+    request = {
+        "custom_fields": {"configuration": {"foo": "bar"}},
+        "messages": [
+            {
+                "role": "user",
+                "content": "hi",
+                "custom_content": {
+                    "state": {"a": 1},
+                    "stages": [],
+                    "attachments": [],
+                },
+                "custom_fields": {"unknown": 1},
+            }
+        ],
+        "tools": [
+            {
+                "type": "function",
+                "function": {"name": "f"},
+                "custom_fields": {"cache_breakpoint": {}},
+            }
+        ],
+    }
+
+    assert normalize_dial_request(request) == {
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [{"type": "function", "function": {"name": "f"}}],
+    }
+
+
+def test_parsing_collects_every_dial_field():
+    request = {
+        "custom_fields": {"configuration": {"foo": "bar"}},
+        "messages": [
+            {"role": "system", "content": "sys"},
+            {
+                "role": "user",
+                "content": "hi",
+                "custom_content": {"state": {"a": 1}},
+                "custom_fields": {"cache_breakpoint": {}},
+            },
+        ],
+        "tools": [
+            {
+                "type": "function",
+                "function": {"name": "f"},
+                "custom_fields": {"cache_breakpoint": {}},
+            }
+        ],
+    }
+
+    parsed, features = _parse_dial_request(request)
+
+    assert parsed == {
+        "messages": [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+        ],
+        "tools": [{"type": "function", "function": {"name": "f"}}],
+    }
+    assert features == DialFeatures(
+        custom_fields={"configuration": {"foo": "bar"}},
+        message_custom_content={1: {"state": {"a": 1}}},
+        message_custom_fields={1: {"cache_breakpoint": {}}},
+        tool_custom_fields={0: {"cache_breakpoint": {}}},
+    )
+
+
+def test_request_is_not_mutated():
+    message = {
+        "role": "user",
+        "content": [{"type": "text", "text": "hi"}],
+        "custom_fields": {"cache_breakpoint": {}},
+    }
+    request = {"messages": [message]}
+
+    normalize_dial_request(request)
+
+    assert request == {
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "hi"}],
+                "custom_fields": {"cache_breakpoint": {}},
+            }
+        ]
+    }
+
+
+def test_static_tool_is_rejected():
+    request = {
+        "messages": [],
+        "tools": [
+            {"type": "function", "function": {"name": "f"}},
+            {"type": "static_function", "static_function": {"name": "g"}},
+        ],
+    }
+
+    with pytest.raises(InvalidRequestError, match=r"tools\[1\]"):
+        normalize_dial_request(request)
+
+
+def test_malformed_dial_field_is_rejected():
+    request = {"messages": [{"role": "user", "custom_fields": "oops"}]}
+
+    with pytest.raises(InvalidRequestError):
+        normalize_dial_request(request)
+
+
+def test_unexpected_error_leaves_the_request_intact():
+    request = {"messages": 42, "custom_fields": {"configuration": {}}}
+
+    assert normalize_dial_request(request) is request
+
+
+_API_VERSION = "api-version=2023-03-15-preview"
+_UPSTREAM_ENDPOINT = (
+    "http://localhost:5001/openai/deployments/gpt-4/chat/completions"
+)
+
+
+@respx.mock
+async def test_dial_fields_are_not_proxied_upstream(
+    test_app: httpx.AsyncClient,
+):
+    upstream_body: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal upstream_body
+        upstream_body = json.loads(request.content)
+        return httpx.Response(
+            status_code=200,
+            json=OpenAIStream(
+                single_choice_chunk(
+                    finish_reason="stop",
+                    delta={"role": "assistant", "content": "hello"},
+                )
+            ).to_block_response(),
+        )
+
+    respx.post(f"{_UPSTREAM_ENDPOINT}?{_API_VERSION}").mock(side_effect=handler)
+
+    response = await test_app.post(
+        f"/openai/deployments/gpt-4/chat/completions?{_API_VERSION}",
+        json={
+            "stream": False,
+            "custom_fields": {"configuration": {"foo": "bar"}},
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "hi",
+                    "custom_fields": {"cache_breakpoint": {}},
+                    "custom_content": {"state": {"a": 1}},
+                }
+            ],
+        },
+        headers={
+            "X-UPSTREAM-KEY": "TEST_API_KEY",
+            "X-UPSTREAM-ENDPOINT": _UPSTREAM_ENDPOINT,
+        },
+    )
+
+    assert response.status_code == 200
+    assert "custom_fields" not in upstream_body
+    assert upstream_body["messages"] == [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "hi", **_EXPLICIT}],
+        }
+    ]

--- a/tests/unit_tests/test_storage.py
+++ b/tests/unit_tests/test_storage.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from aidial_client import DialException
-from aidial_client.types.metadata import FileMetadata
+from aidial_client.types.metadata import FileItem
 from aidial_sdk.exceptions import InvalidRequestError
 
 from aidial_adapter_openai.dial_api.storage import FileStorage
@@ -18,7 +18,7 @@ def _make_dial_client(
     *,
     appdata_home: PurePosixPath | None = None,
     files_home: PurePosixPath | None = None,
-    upload_result: FileMetadata | None = None,
+    upload_result: FileItem | None = None,
     download_result: bytes = b"from-sdk",
     download_error: Exception | None = None,
 ):
@@ -49,7 +49,7 @@ def _make_dial_client(
 
 @pytest.mark.asyncio
 async def test_upload_uses_dial_client_sdk(monkeypatch):
-    metadata = FileMetadata(
+    metadata = FileItem(
         name="sha256.png",
         parent_path="images",
         bucket="user-bucket",

--- a/tests/utils/storage.py
+++ b/tests/utils/storage.py
@@ -8,7 +8,7 @@ from typing_extensions import override
 
 from aidial_adapter_openai.dial_api.resource import ValidationError
 from aidial_adapter_openai.dial_api.storage import (
-    FileMetadata,
+    FileItem,
     FileStorage,
 )
 from aidial_adapter_openai.utils.env import get_env_bool
@@ -72,7 +72,7 @@ class MockFileStorage(FileStorage):
 
     async def upload(
         self, upload_dir: str, filename: str, content_type: str, content: bytes
-    ) -> FileMetadata:
+    ) -> FileItem:
         ext = self._get_file_extension(content_type)
         name = self._get_fresh_filename() + ext
 
@@ -80,7 +80,7 @@ class MockFileStorage(FileStorage):
         file.write_bytes(content)
         self.files.append(file)
 
-        return FileMetadata(
+        return FileItem(
             name=name,
             parent_path=os.path.dirname(name),
             bucket="mock-bucket",


### PR DESCRIPTION
DIAL extends the Chat Completions request with fields of its own. Upstreams which receive the request nearly as-is validate it strictly and reject the unknown fields.

Request to a FireWorks deployment:

```sh
curl --location 'http://localhost:8080/openai/deployments/fw.glm-5.2/chat/completions?api-version=2024-08-06' \
--header 'api-Key: dial_api_key' \
--header 'Content-Type: application/json' \
--data '{
    "stream": false,
    "messages": [
        {
            "role": "user",
            "content": "hi",
            "custom_fields": {
                "cache_breakpoint": {}
            }
        }
    ]
}'
```

Response:

```json
{
    "error": {
        "message": "Extra inputs are not permitted, field: 'messages[0].custom_fields'",
        "type": "invalid_request_error",
        "code": "invalid_request_error",
        "object": "error"
    }
}
```

The request is now normalized right before proxying:

* `messages[*].custom_fields.cache_breakpoint` is converted to the native `prompt_cache_breakpoint` of the message's last content part,
* `custom_fields`, `messages[*].custom_content` and `tools[*].custom_fields` are dropped and reported in a single warning.