### PR TITLE
feat: Responses API: support DIAL caching

### DIFF
--- a/aidial_adapter_openai/chat_completions/gpt.py
+++ b/aidial_adapter_openai/chat_completions/gpt.py
@@ -1,14 +1,21 @@
 from collections.abc import AsyncIterator, Mapping
+from typing import cast
 
 from openai import AsyncAzureOpenAI, AsyncOpenAI, AsyncStream
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
+from openai.types.chat.completion_create_params import (
+    CompletionCreateParamsBase,
+)
 
 from aidial_adapter_openai.chat_completions.transformation import (
     ResourceProcessor,
 )
 from aidial_adapter_openai.dial_api.request import extract_max_prompt_tokens
 from aidial_adapter_openai.dial_api.storage import FileStorage
-from aidial_adapter_openai.utils.caching import get_response_headers_for_caching
+from aidial_adapter_openai.utils.caching import (
+    build_cache_headers,
+    get_chat_completions_breakpoint_path,
+)
 from aidial_adapter_openai.utils.log_config import logger
 from aidial_adapter_openai.utils.multi_modal_message import MultiModalMessage
 from aidial_adapter_openai.utils.reflection import call_with_extra_body
@@ -60,6 +67,12 @@ async def chat_completion(
     n: int = request.get("n") or 1
     model_name = request["model"]
 
+    # Computed upfront: the path must address the request body
+    # as DIAL Core has sent it, before the truncation reindexes messages.
+    breakpoint_path = get_chat_completions_breakpoint_path(
+        cast(CompletionCreateParamsBase, request)
+    )
+
     max_prompt_tokens = extract_max_prompt_tokens(request)
     discarded_messages: DiscardedMessages | None
 
@@ -103,9 +116,9 @@ async def chat_completion(
     ) = await call_with_extra_body(client.chat.completions.create, request)
 
     if isinstance(response, AsyncStream):
-        response_headers = await get_response_headers_for_caching(
+        response_headers = await build_cache_headers(
             request_headers=request_headers,
-            request_body=request,
+            breakpoint_path=breakpoint_path,
             get_request_tokens=get_prompt_tokens,
         )
 
@@ -133,9 +146,9 @@ async def chat_completion(
         async def get_request_tokens():
             return actual_prompt_tokens or await get_prompt_tokens()
 
-        response_headers = await get_response_headers_for_caching(
+        response_headers = await build_cache_headers(
             request_headers=request_headers,
-            request_body=request,
+            breakpoint_path=breakpoint_path,
             get_request_tokens=get_request_tokens,
         )
 

--- a/aidial_adapter_openai/endpoints/chat_completion.py
+++ b/aidial_adapter_openai/endpoints/chat_completion.py
@@ -148,6 +148,7 @@ async def call_chat_completion(
         case D.RESPONSES_API:
             return await responses(
                 request=request_body,
+                request_headers=request_headers,
                 client=client,
                 file_storage=file_storage,
                 vendor=vendor,

--- a/aidial_adapter_openai/endpoints/responses.py
+++ b/aidial_adapter_openai/endpoints/responses.py
@@ -119,9 +119,8 @@ async def responses_create(request: Request) -> FastAPIResponse:
 
     response_with_headers = _to_response_with_headers(
         response,
-        # Reported for a successful generation only: the SDK raises on a 4xx/5xx
-        # upstream response, so a failed request never claims the affinity to an
-        # upstream whose provider cache DIAL Core would find cold on a retry.
+        # Reported for a successful generation only, since
+        # the SDK raises on a 4xx/5xx upstream response
         extra_headers=await build_cache_headers(
             request_headers=request.headers,
             breakpoint_path=get_responses_breakpoint_path(

--- a/aidial_adapter_openai/endpoints/responses.py
+++ b/aidial_adapter_openai/endpoints/responses.py
@@ -1,6 +1,6 @@
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
-from typing import Self, TypeVar
+from typing import Self, TypeVar, cast
 
 from fastapi import Request
 from fastapi.responses import Response as FastAPIResponse
@@ -14,6 +14,9 @@ from openai._legacy_response import LegacyAPIResponse
 from openai.types.responses import Response
 from openai.types.responses.input_token_count_response import (
     InputTokenCountResponse,
+)
+from openai.types.responses.response_create_params import (
+    ResponseCreateParamsBase,
 )
 from openai.types.responses.response_stream_event import ResponseStreamEvent
 
@@ -30,6 +33,10 @@ from aidial_adapter_openai.dial_api.storage import (
 )
 from aidial_adapter_openai.responses.request import (
     download_dial_urls_in_request,
+)
+from aidial_adapter_openai.utils.caching import (
+    build_cache_headers,
+    get_responses_breakpoint_path,
 )
 from aidial_adapter_openai.utils.client import get_client
 from aidial_adapter_openai.utils.parsers import (
@@ -110,7 +117,17 @@ async def responses_create(request: Request) -> FastAPIResponse:
         context.client.responses.with_raw_response.create, request_body
     )
 
-    response_with_headers = _to_response_with_headers(response)
+    response_with_headers = _to_response_with_headers(
+        response,
+        # Reported for a successful generation only: a failed request makes
+        # DIAL Core try another upstream, whose provider cache is cold.
+        extra_headers=await build_cache_headers(
+            request_headers=request.headers,
+            breakpoint_path=get_responses_breakpoint_path(
+                cast(ResponseCreateParamsBase, request_body)
+            ),
+        ),
+    )
     return await _to_fast_api_response(request, response_with_headers)
 
 
@@ -191,6 +208,8 @@ async def _to_fast_api_response(
 
 def _to_response_with_headers(
     response: LegacyAPIResponse[_ResponsesPayloadT],
+    *,
+    extra_headers: dict[str, str] | None = None,
 ) -> ResponseWithHeaders[dict | AsyncIterator[dict]]:
     response_headers = response.http_response.headers
 
@@ -208,7 +227,9 @@ def _to_response_with_headers(
     else:
         body = _to_dict(parsed_response)
 
-    return ResponseWithHeaders(headers=dict(response_headers), body=body)
+    return ResponseWithHeaders(
+        headers={**response_headers, **(extra_headers or {})}, body=body
+    )
 
 
 def _to_dict(

--- a/aidial_adapter_openai/endpoints/responses.py
+++ b/aidial_adapter_openai/endpoints/responses.py
@@ -119,8 +119,9 @@ async def responses_create(request: Request) -> FastAPIResponse:
 
     response_with_headers = _to_response_with_headers(
         response,
-        # Reported for a successful generation only: a failed request makes
-        # DIAL Core try another upstream, whose provider cache is cold.
+        # Reported for a successful generation only: the SDK raises on a 4xx/5xx
+        # upstream response, so a failed request never claims the affinity to an
+        # upstream whose provider cache DIAL Core would find cold on a retry.
         extra_headers=await build_cache_headers(
             request_headers=request.headers,
             breakpoint_path=get_responses_breakpoint_path(

--- a/aidial_adapter_openai/responses/adapter.py
+++ b/aidial_adapter_openai/responses/adapter.py
@@ -1,7 +1,7 @@
 import json
 import logging
-from collections.abc import AsyncIterator
-from typing import Any, assert_never
+from collections.abc import AsyncIterator, Mapping
+from typing import Any, assert_never, cast
 
 from aidial_sdk.exceptions import RequestValidationError
 from openai import (
@@ -10,6 +10,9 @@ from openai import (
     AsyncOpenAI,
     AsyncStream,
     BaseModel,
+)
+from openai.types.chat.completion_create_params import (
+    CompletionCreateParamsBase,
 )
 
 from aidial_adapter_openai.configuration.app_config import Vendor
@@ -22,8 +25,13 @@ from aidial_adapter_openai.responses.converter import (
 )
 from aidial_adapter_openai.responses.event_handler import EventHandler
 from aidial_adapter_openai.responses.tokenizer import ResponsesRequestTokenizer
+from aidial_adapter_openai.utils.caching import (
+    build_cache_headers,
+    get_chat_completions_breakpoint_path,
+)
 from aidial_adapter_openai.utils.log_config import logger
 from aidial_adapter_openai.utils.streaming import (
+    ResponseWithHeaders,
     add_statistics_to_response,
     map_stream,
     map_stream_generator,
@@ -125,11 +133,21 @@ async def _truncate_prompt(
 async def chat_completion(
     *,
     request: dict[str, Any],
+    request_headers: Mapping[str, str],
     client: AsyncAzureOpenAI | AsyncOpenAI | AsyncBedrockOpenAI,
     file_storage: FileStorage | None,
     vendor: Vendor,
-) -> AsyncIterator[dict] | dict:
+) -> ResponseWithHeaders[AsyncIterator[dict] | dict]:
     _validate_request(request)
+
+    # Computed upfront: the path must address the request body
+    # as DIAL Core has sent it, before the truncation reindexes messages.
+    response_headers = await build_cache_headers(
+        request_headers=request_headers,
+        breakpoint_path=get_chat_completions_breakpoint_path(
+            cast(CompletionCreateParamsBase, request)
+        ),
+    )
 
     discarded_messages = None
     if (max_prompt_tokens := extract_max_prompt_tokens(request)) is not None:
@@ -146,13 +164,11 @@ async def chat_completion(
     )
     response = await client.responses.create(**create_request)
 
+    body: AsyncIterator[dict] | dict
     if isinstance(response, AsyncStream):
         handler = EventHandler()
-        stream = map_stream(
+        body = map_stream(
             _to_dict, map_stream_generator(handler.handle, response)
-        )
-        return add_statistics_to_response(
-            stream, discarded_messages=discarded_messages
         )
     else:
         if logger.isEnabledFor(logging.DEBUG):
@@ -160,7 +176,10 @@ async def chat_completion(
                 f"responses API response: {json.dumps(response.model_dump())}"
             )
         body = _to_dict(convert_response(response))
-        body = add_statistics_to_response(
+
+    return ResponseWithHeaders(
+        headers=response_headers,
+        body=add_statistics_to_response(
             body, discarded_messages=discarded_messages
-        )
-        return body
+        ),
+    )

--- a/aidial_adapter_openai/utils/caching.py
+++ b/aidial_adapter_openai/utils/caching.py
@@ -1,6 +1,12 @@
 import time
 from collections.abc import Callable, Coroutine, Mapping
-from typing import Any
+
+from openai.types.chat.completion_create_params import (
+    CompletionCreateParamsBase,
+)
+from openai.types.responses.response_create_params import (
+    ResponseCreateParamsBase,
+)
 
 _DIAL_CACHE_BREAKPOINT_PATH = "X-DIAL-CACHE-BREAKPOINT-PATH"
 _DIAL_CACHE_EXPIRE_AT = "X-DIAL-CACHE-EXPIRE-AT"
@@ -17,42 +23,58 @@ _DEFAULT_TTL_SEC = 5 * 60  # 5 minutes
 _PROMPT_TOKENS_THRESHOLD = 1024
 
 
-def _get_last_message_idx(request_body: Any) -> int | None:
-    if not isinstance(request_body, dict):
+def get_chat_completions_breakpoint_path(
+    request: CompletionCreateParamsBase,
+) -> str | None:
+    messages = request.get("messages")
+    if not isinstance(messages, list) or not messages:
         return None
 
-    messages = request_body.get("messages") or []
-    if not isinstance(messages, list):
-        return None
-
-    if not messages:
-        return None
-
-    return len(messages) - 1
+    return f"prefix.body.messages[{len(messages) - 1}]"
 
 
-async def get_response_headers_for_caching(
+def get_responses_breakpoint_path(
+    request: ResponseCreateParamsBase,
+) -> str | None:
+    input = request.get("input")
+    if isinstance(input, list):
+        if input:
+            return f"prefix.body.input[{len(input) - 1}]"
+    elif input is not None:
+        # A scalar where an array is expected counts as a one-element array,
+        # the way DIAL Core hashes it: `"input": "hi"` is `input[0]`.
+        return "prefix.body.input[0]"
+
+    # No input at all: the instructions are the only prefix left to cache.
+    if request.get("instructions"):
+        return "prefix.body.instructions[0]"
+
+    return None
+
+
+async def build_cache_headers(
     *,
     request_headers: Mapping[str, str],
-    request_body: Any,
-    get_request_tokens: Callable[[], Coroutine[None, None, int]],
+    breakpoint_path: str | None,
+    get_request_tokens: (
+        Callable[[], Coroutine[None, None, int]] | None
+    ) = None,
 ) -> dict[str, str] | None:
     # DIAL Core always sends this header if the deployment
     # is marked in listing as supporting auto-caching
     if request_headers.get(_DIAL_CACHE_BREAKPOINT_PATH) is None:
         return None
 
-    if (last_message_idx := _get_last_message_idx(request_body)) is None:
+    if breakpoint_path is None:
         return None
 
-    path = f"prefix.body.messages[{last_message_idx}]"
-    expire_at = str(int(time.time()) + _DEFAULT_TTL_SEC)
-
-    prompt_tokens = await get_request_tokens()
-    if prompt_tokens < _PROMPT_TOKENS_THRESHOLD:
+    if (
+        get_request_tokens is not None
+        and await get_request_tokens() < _PROMPT_TOKENS_THRESHOLD
+    ):
         return None
 
     return {
-        _DIAL_CACHE_BREAKPOINT_PATH: path,
-        _DIAL_CACHE_EXPIRE_AT: expire_at,
+        _DIAL_CACHE_BREAKPOINT_PATH: breakpoint_path,
+        _DIAL_CACHE_EXPIRE_AT: str(int(time.time()) + _DEFAULT_TTL_SEC),
     }

--- a/tests/unit_tests/test_responses_dial_caching.py
+++ b/tests/unit_tests/test_responses_dial_caching.py
@@ -1,0 +1,191 @@
+import json
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from aidial_adapter_openai.utils.caching import (
+    get_responses_breakpoint_path,
+)
+from tests.conftest import OpenAIClientFactory
+from tests.utils.mock_server import MockServer
+
+_CACHE_BREAKPOINT_PATH = "X-DIAL-CACHE-BREAKPOINT-PATH"
+_CACHE_EXPIRE_AT = "X-DIAL-CACHE-EXPIRE-AT"
+
+_UPSTREAM_ENDPOINT = "https://api.openai.com/v1/responses"
+
+CHAT_COMPLETIONS_INPUT = RESPONSES_INPUT = [
+    {"role": "system", "content": "be a helpful assistant"},
+    {"role": "user", "content": "2+3=?"},
+]
+
+
+@pytest.fixture(params=[False, True], ids=["block", "stream"])
+def stream(request) -> bool:
+    return request.param
+
+
+@pytest.fixture(params=[False, True], ids=["caching-off", "caching-on"])
+def caching_enabled(request) -> bool:
+    return request.param
+
+
+def _mock_upstream_response():
+    MockServer().post(_UPSTREAM_ENDPOINT)(
+        MockServer.mock_responses_api_response("text.txt")
+    )
+
+
+def _caching_headers(caching_enabled: bool) -> dict[str, str]:
+    # DIAL Core sends the header if the deployment
+    # is marked in listing as supporting auto-caching
+    return {_CACHE_BREAKPOINT_PATH: "whatever"} if caching_enabled else {}
+
+
+async def _post_chat_completions(
+    test_app: httpx.AsyncClient,
+    *,
+    messages: list[dict[str, Any]],
+    stream: bool,
+    caching_enabled: bool = True,
+    **extra_body: Any,
+) -> httpx.Response:
+    return await test_app.post(
+        "/openai/deployments/adapter-deployment-name/chat/completions?api-version=2023-03-15-preview",
+        json={
+            "model": "upstream-model-name",
+            "stream": stream,
+            "messages": messages,
+            **extra_body,
+        },
+        headers={
+            "X-UPSTREAM-KEY": "test-api-key",
+            "X-UPSTREAM-ENDPOINT": _UPSTREAM_ENDPOINT,
+            **_caching_headers(caching_enabled),
+        },
+    )
+
+
+def _assert_breakpoint_path(
+    response: httpx.Response | Any, expected_path: str | None
+):
+    if expected_path is None:
+        assert _CACHE_BREAKPOINT_PATH not in response.headers
+        assert _CACHE_EXPIRE_AT not in response.headers
+    else:
+        assert response.headers[_CACHE_BREAKPOINT_PATH] == expected_path
+        assert int(response.headers[_CACHE_EXPIRE_AT]) > 0
+
+
+def _discarded_messages(response: httpx.Response) -> list[int] | None:
+    if response.headers["content-type"].startswith("text/event-stream"):
+        body = [
+            json.loads(line.removeprefix("data: "))
+            for line in response.text.splitlines()
+            if line.startswith("data: ") and line != "data: [DONE]"
+        ][-1]
+    else:
+        body = response.json()
+
+    return (body.get("statistics") or {}).get("discarded_messages")
+
+
+@pytest.mark.parametrize(
+    "request_body,expected_path",
+    [
+        ({"input": RESPONSES_INPUT}, "prefix.body.input[1]"),
+        ({"input": "2+3=?"}, "prefix.body.input[0]"),
+        (
+            {"input": [], "instructions": "be a helpful assistant"},
+            "prefix.body.instructions[0]",
+        ),
+        (
+            {"instructions": "be a helpful assistant"},
+            "prefix.body.instructions[0]",
+        ),
+        ({"input": []}, None),
+        ({}, None),
+    ],
+)
+def test_responses_breakpoint_path(
+    request_body: Any, expected_path: str | None
+):
+    assert get_responses_breakpoint_path(request_body) == expected_path
+
+
+@respx.mock
+async def test_passthrough_auto_caching(
+    create_openai_client: OpenAIClientFactory,
+    stream: bool,
+    caching_enabled: bool,
+):
+    _mock_upstream_response()
+    client = create_openai_client(upstream_endpoint=_UPSTREAM_ENDPOINT)
+
+    response = await client.responses.with_raw_response.create(
+        model="upstream-model-name",
+        input=RESPONSES_INPUT,  # type: ignore[arg-type]
+        stream=stream,
+        extra_headers=_caching_headers(caching_enabled),
+    )
+
+    _assert_breakpoint_path(
+        response, "prefix.body.input[1]" if caching_enabled else None
+    )
+
+
+@respx.mock
+async def test_adapter_auto_caching(
+    test_app: httpx.AsyncClient, stream: bool, caching_enabled: bool
+):
+    _mock_upstream_response()
+
+    response = await _post_chat_completions(
+        test_app,
+        messages=CHAT_COMPLETIONS_INPUT,
+        stream=stream,
+        caching_enabled=caching_enabled,
+    )
+
+    assert response.status_code == 200
+    # The adapter is called with a Chat Completions API request,
+    # so the breakpoint addresses its messages
+    _assert_breakpoint_path(
+        response, "prefix.body.messages[1]" if caching_enabled else None
+    )
+
+
+@respx.mock
+async def test_adapter_auto_caching_with_truncation(
+    test_app: httpx.AsyncClient, stream: bool
+):
+    """The breakpoint addresses the request as DIAL Core has sent it,
+    regardless of the messages discarded by the adapter."""
+
+    _mock_upstream_response()
+    token_counts = iter([100, 80, 40])
+
+    @MockServer().post(f"{_UPSTREAM_ENDPOINT}/input_tokens")
+    def _count_tokens(_request: httpx.Request):
+        return {
+            "object": "response.input_tokens",
+            "input_tokens": next(token_counts),
+        }
+
+    response = await _post_chat_completions(
+        test_app,
+        messages=[
+            {"role": "system", "content": "be a helpful assistant"},
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+            {"role": "user", "content": "2+3=?"},
+        ],
+        stream=stream,
+        max_prompt_tokens=50,
+    )
+
+    assert response.status_code == 200
+    assert _discarded_messages(response) == [1, 2]
+    _assert_breakpoint_path(response, "prefix.body.messages[3]")


### PR DESCRIPTION
Report the DIAL cache headers `X-DIAL-CACHE-BREAKPOINT-PATH`, `X-DIAL-CACHE-EXPIRE-AT` for the Responses API. 

Both modes are covered: 
* the adapter (`/chat/completions`, breakpoint addresses `messages`) and 
* the passthrough (`/openai/v1/responses`, breakpoint addresses `input`/`instructions`).

Follows [ai-dial-adapter-anthropic#88](https://github.com/epam/ai-dial-adapter-anthropic/pull/88), which did the same for the Messages API.