### PR TITLE
feat: AWS Bedrock: support models backed by bedrock-runtime endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,8 +673,19 @@ Note the difference from the Azure OpenAI configuration:
 
 #### Amazon Bedrock OpenAI Chat Completions API
 
-The adapter supports OpenAI models deployed through Amazon Bedrock Mantle.
-Use a Bedrock model id with the `openai.` prefix in `overrideName` (for example `openai.gpt-5.4`):
+The adapter supports OpenAI models deployed through Amazon Bedrock. Two upstream endpoint formats are recognized:
+
+- **Bedrock Mantle** - `https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1/chat/completions`
+- **Bedrock Runtime** - `https://bedrock-runtime.${AWS_REGION}.amazonaws.com/openai/v1/chat/completions`
+
+Both formats are authenticated the same way, but they expect different model ids in `overrideName`:
+
+|Upstream endpoint|`overrideName`|
+|---|---|
+|Bedrock Mantle|`openai.gpt-5.4`|
+|Bedrock Runtime|`us.openai.gpt-5.4` *(the model id prefixed with the region)*|
+
+Model availability differs between the two formats - check the [AWS OpenAI model cards](https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards-openai.html) before choosing one.
 
 <details><summary>DIAL Core Config</summary>
 
@@ -698,7 +709,7 @@ Use a Bedrock model id with the `openai.` prefix in `overrideName` (for example 
 
 </details>
 
-As in other v1-style upstreams, set `overrideName` to the Bedrock model id (for example `openai.gpt-5.4`).
+As in other v1-style upstreams, set `overrideName` to the Bedrock model id.
 
 > [!NOTE]
 > Bedrock support and feature parity can differ from direct OpenAI API support. Validate your model, region, and required capabilities before rollout:
@@ -1465,7 +1476,12 @@ Whereas, `endpoint` URL is required and enables Chat Completions API in DIAL.
 #### Amazon Bedrock OpenAI Responses API
 
 > [!IMPORTANT]
-> Use `overrideName` with a Bedrock model id in `openai.*` format (for example `openai.gpt-5.4`).
+> Use `overrideName` with a Bedrock model id in `openai.*` format. Bedrock Mantle takes the plain model id *(`openai.gpt-5.4`)*, while Bedrock Runtime expects it prefixed with the region *(`us.openai.gpt-5.4`)*.
+
+Both Bedrock upstream endpoint formats are supported:
+
+- **Bedrock Mantle** - `https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1/responses`
+- **Bedrock Runtime** - `https://bedrock-runtime.${AWS_REGION}.amazonaws.com/openai/v1/responses`
 
 <details><summary>DIAL Core Config</summary>
 

--- a/aidial_adapter_openai/utils/parsers.py
+++ b/aidial_adapter_openai/utils/parsers.py
@@ -1,11 +1,13 @@
 import re
 from http import HTTPStatus
 from json import JSONDecodeError
-from typing import Any
+from typing import Any, Literal, assert_never
 from urllib.parse import urlparse
 
 from aidial_sdk.exceptions import HTTPException, InvalidRequestError
 from anthropic import AsyncAnthropic, AsyncAnthropicFoundry
+from aws_bedrock_token_generator import provide_token
+from botocore.credentials import CredentialProvider, Credentials
 from fastapi import Request
 from openai import AsyncAzureOpenAI, AsyncBedrockOpenAI, AsyncOpenAI
 from typing_extensions import TypedDict
@@ -107,10 +109,39 @@ class BedrockOpenAIClientParams(TypedDict, total=False):
     aws_session_token: str | None
 
 
+class _StaticCredentialProvider(CredentialProvider):
+    def __init__(self, credentials: Credentials) -> None:
+        super().__init__()
+        self._credentials = credentials
+
+    def load(self) -> Credentials:  # type: ignore[reportIncompatibleMethodOverride]
+        return self._credentials
+
+
+def _get_credential_provider(
+    params: OpenAIParams,
+) -> CredentialProvider | None:
+    access_key_id = params.get("aws_access_key_id")
+    secret_access_key = params.get("aws_secret_access_key")
+
+    if not access_key_id or not secret_access_key:
+        return None
+
+    return _StaticCredentialProvider(
+        Credentials(
+            access_key=access_key_id,
+            secret_key=secret_access_key,
+            token=params.get("aws_session_token"),
+        )
+    )
+
+
 class BedrockOpenAIEndpoint(ExtraForbidModel):
     bedrock_region: str
+    client: Literal["runtime", "mantle"]
+    openai_base_url: str
 
-    def get_client(self, params: OpenAIParams) -> AsyncBedrockOpenAI:
+    def _build_mantle(self, params: OpenAIParams) -> AsyncBedrockOpenAI:
         api_key = params.get("api_key")
         client_params: BedrockOpenAIClientParams = {}
 
@@ -130,6 +161,34 @@ class BedrockOpenAIEndpoint(ExtraForbidModel):
             **client_params,
         )
 
+    def _build_runtime(self, params: OpenAIParams) -> AsyncOpenAI:
+        api_key = params.get("api_key")
+
+        if not api_key:
+            api_key = provide_token(
+                self.bedrock_region,
+                aws_credentials_provider=_get_credential_provider(params),
+            )
+
+        return AsyncOpenAI(
+            base_url=self.openai_base_url,
+            api_key=api_key,
+            max_retries=_MAX_RETRIES,
+            default_headers=params.get("headers"),
+            http_client=get_http_client(),
+        )
+
+    def get_client(
+        self, params: OpenAIParams
+    ) -> AsyncBedrockOpenAI | AsyncOpenAI:
+        match self.client:
+            case "mantle":
+                return self._build_mantle(params)
+            case "runtime":
+                return self._build_runtime(params)
+            case _:
+                assert_never(self.client)
+
 
 def _parse_endpoint(
     name: str | None, endpoint: str
@@ -144,7 +203,17 @@ def _parse_endpoint(
         r"https?://bedrock-mantle\.([a-z0-9-]+)\.api\.aws(?:/.*)?",
         endpoint,
     ):
-        return BedrockOpenAIEndpoint(bedrock_region=match[1])
+        return BedrockOpenAIEndpoint(
+            bedrock_region=match[1], client="mantle", openai_base_url=endpoint
+        )
+
+    if match := re.fullmatch(
+        r"https?://bedrock-runtime\.([a-z0-9-]+)\.amazonaws\.com(?:/.*)?",
+        endpoint,
+    ):
+        return BedrockOpenAIEndpoint(
+            bedrock_region=match[1], client="runtime", openai_base_url=endpoint
+        )
 
     # Last generation API
     if match := re.fullmatch("(.+?)/openai/deployments/(.+)", endpoint):

--- a/poetry.lock
+++ b/poetry.lock
@@ -427,6 +427,24 @@ tests = ["attrs[tests-no-zope]", "zope-interface"]
 tests-no-zope = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothesis", "mypy (>=1.1.1) ; platform_python_implementation == \"CPython\"", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version < \"3.11\"", "pytest-xdist[psutil]"]
 
 [[package]]
+name = "aws-bedrock-token-generator"
+version = "1.1.0"
+description = "A lightweight library for generating short-term bearer tokens for AWS Bedrock API authentication"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "aws_bedrock_token_generator-1.1.0-py3-none-any.whl", hash = "sha256:bd12854f7c7e52dde5d980d369379f12d0cc5f0855099d87f38688b0f9de5cd4"},
+    {file = "aws_bedrock_token_generator-1.1.0.tar.gz", hash = "sha256:95ccb07f63a91ac486561f6df05cc4e04784c8ff5086dc687ed9c5fd3ab1b5ba"},
+]
+
+[package.dependencies]
+botocore = ">=1.33.0"
+
+[package.extras]
+dev = ["black (>=21.0)", "flake8 (>=3.8)", "mypy (>=0.800)", "pytest (>=6.0)", "pytest-cov (>=2.0)"]
+
+[[package]]
 name = "azure-core"
 version = "1.38.0"
 description = "Microsoft Azure Core Library for Python"
@@ -3462,4 +3480,4 @@ test = ["big-O", "importlib-resources ; python_version < \"3.9\"", "jaraco.funct
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "6dcd99390a208b962b53ef48ee66541a327344df1ab169328f386384512dfbbf"
+content-hash = "61e69d56788e8249f648271dafacedb2ea635b2e2d2dddc6f6e7b99e85603565"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ anthropic = "0.105.0"
 jmespath = "1.1.0"
 aidial-client = "0.11.0"
 boto3 = "1.43.74"
+aws-bedrock-token-generator = "^1.1.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = "9.0.3"

--- a/tests/integration_tests/test_bedrock.py
+++ b/tests/integration_tests/test_bedrock.py
@@ -12,10 +12,13 @@ from tests.utils.openai import chat_completion, user
 
 D = DeploymentConfig
 
+# Matches both the bedrock-mantle and the bedrock-runtime hosts.
+_BEDROCK_HOST_MARKER = "//bedrock-"
+
 _bedrock_text_deployments: list[D] = [
     deployment
     for deployment in TEST_DEPLOYMENTS_CONFIG.chat_deployments
-    if "bedrock-mantle." in deployment.upstream_endpoint
+    if _BEDROCK_HOST_MARKER in deployment.upstream_endpoint
     and not deployment.supports_video_generation
     and not deployment.supports_tts
     and not deployment.supports_stt

--- a/tests/unit_tests/test_app_config.py
+++ b/tests/unit_tests/test_app_config.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import pytest
 from aidial_sdk.exceptions import HTTPException
 
@@ -100,27 +102,53 @@ def test_app_config_chat_responses_openai_platform(
     )
 
 
-def test_app_config_chat_responses_bedrock(deployment: str):
+_BedrockClient = Literal["mantle", "runtime"]
+
+_BEDROCK_HOSTS: dict[_BedrockClient, str] = {
+    "mantle": "bedrock-mantle.{region}.api.aws",
+    "runtime": "bedrock-runtime.{region}.amazonaws.com",
+}
+
+_BEDROCK_CLIENTS = list(_BEDROCK_HOSTS)
+
+
+def _bedrock_base_url(client: _BedrockClient, region: str) -> str:
+    return f"https://{_BEDROCK_HOSTS[client].format(region=region)}/openai/v1"
+
+
+@pytest.mark.parametrize("client", _BEDROCK_CLIENTS)
+def test_app_config_chat_responses_bedrock(
+    deployment: str, client: _BedrockClient
+):
+    base_url = _bedrock_base_url(client, "us-east-2")
+
     ty = ApplicationConfig().get_chat_completion_deployment_type(
-        deployment,
-        "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses",
+        deployment, f"{base_url}/responses"
     )
 
     assert ty.deployment_type == D.RESPONSES_API
     assert ty.endpoint == BedrockOpenAIEndpoint(
         bedrock_region="us-east-2",
+        client=client,
+        openai_base_url=base_url,
     )
 
 
-def test_app_config_chat_bedrock_chat_completions(deployment: str):
+@pytest.mark.parametrize("client", _BEDROCK_CLIENTS)
+def test_app_config_chat_bedrock_chat_completions(
+    deployment: str, client: _BedrockClient
+):
+    base_url = _bedrock_base_url(client, "eu-west-1")
+
     ty = ApplicationConfig().get_chat_completion_deployment_type(
-        deployment,
-        "https://bedrock-mantle.eu-west-1.api.aws/openai/v1/chat/completions",
+        deployment, f"{base_url}/chat/completions"
     )
 
     assert ty.deployment_type == D.GPT_GENERIC
     assert ty.endpoint == BedrockOpenAIEndpoint(
         bedrock_region="eu-west-1",
+        client=client,
+        openai_base_url=base_url,
     )
 
 
@@ -269,12 +297,20 @@ def test_get_vendor_for_vllm_families(cfg: ApplicationConfig):
     )
 
 
-def test_get_vendor_for_bedrock_endpoint(deployment: str):
+@pytest.mark.parametrize("client", _BEDROCK_CLIENTS)
+def test_get_vendor_for_bedrock_endpoint(
+    deployment: str, client: _BedrockClient
+):
+    region = "us-east-2"
     cfg = ApplicationConfig()
     assert (
         cfg.get_vendor(
             deployment,
-            BedrockOpenAIEndpoint(bedrock_region="us-east-2"),
+            BedrockOpenAIEndpoint(
+                bedrock_region=region,
+                client=client,
+                openai_base_url=_bedrock_base_url(client, region),
+            ),
         )
         == Vendor.AWS
     )

--- a/tests/unit_tests/test_auth.py
+++ b/tests/unit_tests/test_auth.py
@@ -16,7 +16,18 @@ from aidial_adapter_openai.utils.upstream_headers import (
 )
 
 _REGION = "us-east-1"
-_ENDPOINT = BedrockOpenAIEndpoint(bedrock_region=_REGION)
+_ENDPOINTS = [
+    BedrockOpenAIEndpoint(
+        bedrock_region=_REGION,
+        client="mantle",
+        openai_base_url=f"https://bedrock-mantle.{_REGION}.api.aws/openai/v1",
+    ),
+    BedrockOpenAIEndpoint(
+        bedrock_region=_REGION,
+        client="runtime",
+        openai_base_url=f"https://bedrock-runtime.{_REGION}.amazonaws.com/openai/v1",
+    ),
+]
 _ROLE_ARN = "arn:aws:iam::123456789012:role/BedrockAccess"
 _AWS_ENV_VARS = (
     "AWS_ACCESS_KEY_ID",
@@ -62,6 +73,15 @@ async def test_get_credentials_raises_without_key_for_non_azure():
     error = exc_info.value
     assert error.status_code == 401
     assert error.message == "X-UPSTREAM-KEY header is missing"
+
+
+@pytest.fixture(params=_ENDPOINTS, ids=lambda endpoint: endpoint.client)
+def endpoint(request: pytest.FixtureRequest) -> BedrockOpenAIEndpoint:
+    """
+    Both Bedrock clients resolve the credentials the same way: only the region
+    of the endpoint takes part in it.
+    """
+    return request.param
 
 
 @pytest.fixture(autouse=True)
@@ -140,6 +160,7 @@ def _aws_creds(
 
 
 async def _get_credentials(
+    endpoint: BedrockOpenAIEndpoint,
     extra_data: dict[str, Any] | None = None,
 ) -> OpenAICreds:
     headers = (
@@ -148,7 +169,7 @@ async def _get_credentials(
         else {_UPSTREAM_EXTRA_DATA_HEADER: json.dumps(extra_data)}
     )
     return await auth.get_credentials(
-        headers, vendor=Vendor.AWS, endpoint=_ENDPOINT
+        headers, vendor=Vendor.AWS, endpoint=endpoint
     )
 
 
@@ -202,6 +223,7 @@ async def _get_credentials(
 )
 async def test_credential_resolution(
     monkeypatch: pytest.MonkeyPatch,
+    endpoint: BedrockOpenAIEndpoint,
     extra_data: dict[str, Any] | None,
     env: dict[str, str],
     expected: OpenAICreds,
@@ -209,7 +231,7 @@ async def test_credential_resolution(
     for env_var, value in env.items():
         monkeypatch.setenv(env_var, value)
 
-    assert await _get_credentials(extra_data) == expected
+    assert await _get_credentials(endpoint, extra_data) == expected
 
 
 @pytest.mark.parametrize(
@@ -233,10 +255,10 @@ async def test_credential_resolution(
     ],
 )
 async def test_incomplete_static_credentials_are_rejected(
-    extra_data: dict[str, Any], err_msg: str
+    endpoint: BedrockOpenAIEndpoint, extra_data: dict[str, Any], err_msg: str
 ):
     with pytest.raises(DialException) as exc_info:
-        await _get_credentials(extra_data)
+        await _get_credentials(endpoint, extra_data)
 
     error = exc_info.value
     assert error.status_code == 500
@@ -244,9 +266,9 @@ async def test_incomplete_static_credentials_are_rejected(
 
 
 async def test_assume_role_exchanges_the_arn_for_temporary_credentials(
-    sts_client: _StubSTSClient,
+    endpoint: BedrockOpenAIEndpoint, sts_client: _StubSTSClient
 ):
-    creds = await _get_credentials({"aws_assume_role_arn": _ROLE_ARN})
+    creds = await _get_credentials(endpoint, {"aws_assume_role_arn": _ROLE_ARN})
 
     assert creds == _aws_creds("sts-key-1", "sts-secret-1", "sts-token-1")
     assert sts_client.region_name == _REGION
@@ -256,13 +278,15 @@ async def test_assume_role_exchanges_the_arn_for_temporary_credentials(
 
 
 async def test_assumed_credentials_are_reused_until_they_near_expiration(
-    monkeypatch: pytest.MonkeyPatch, sts_client: _StubSTSClient
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint: BedrockOpenAIEndpoint,
+    sts_client: _StubSTSClient,
 ):
     extra_data = {"aws_assume_role_arn": _ROLE_ARN}
 
-    credentials = await _get_credentials(extra_data)
+    credentials = await _get_credentials(endpoint, extra_data)
 
-    assert await _get_credentials(extra_data) == credentials
+    assert await _get_credentials(endpoint, extra_data) == credentials
     assert len(sts_client.calls) == 1
 
     monkeypatch.setattr(
@@ -271,19 +295,19 @@ async def test_assumed_credentials_are_reused_until_they_near_expiration(
         lambda: sts_client.expires_on - auth.EXPIRATION_WINDOW_IN_SEC / 2,
     )
 
-    assert await _get_credentials(extra_data) == _aws_creds(
+    assert await _get_credentials(endpoint, extra_data) == _aws_creds(
         "sts-key-2", "sts-secret-2", "sts-token-2"
     )
     assert len(sts_client.calls) == 2
 
 
 async def test_assume_role_failure_is_reported_as_a_dial_error(
-    sts_client: _StubSTSClient,
+    endpoint: BedrockOpenAIEndpoint, sts_client: _StubSTSClient
 ):
     sts_client.failure = RuntimeError("AccessDenied")
 
     with pytest.raises(DialException) as exc_info:
-        await _get_credentials({"aws_assume_role_arn": _ROLE_ARN})
+        await _get_credentials(endpoint, {"aws_assume_role_arn": _ROLE_ARN})
 
     error = exc_info.value
     assert error.status_code == 500

--- a/tests/unit_tests/test_parsers.py
+++ b/tests/unit_tests/test_parsers.py
@@ -1,7 +1,9 @@
 import pytest
 from aidial_sdk.exceptions import HTTPException as DialException
+from openai import AsyncBedrockOpenAI, AsyncOpenAI
 
 from aidial_adapter_openai.configuration.app_config import ApplicationConfig
+from aidial_adapter_openai.utils import parsers
 from aidial_adapter_openai.utils.parsers import (
     AzureOpenAIEndpoint,
     BedrockOpenAIEndpoint,
@@ -29,6 +31,16 @@ RESPONSE_CASES = [
         "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses",
         BedrockOpenAIEndpoint(
             bedrock_region="us-east-2",
+            client="mantle",
+            openai_base_url="https://bedrock-mantle.us-east-2.api.aws/openai/v1",
+        ),
+    ),
+    (
+        "https://bedrock-runtime.us-east-2.amazonaws.com/openai/v1/responses",
+        BedrockOpenAIEndpoint(
+            bedrock_region="us-east-2",
+            client="runtime",
+            openai_base_url="https://bedrock-runtime.us-east-2.amazonaws.com/openai/v1",
         ),
     ),
 ]
@@ -133,6 +145,23 @@ NORMAL_CHAT_CASES = [
         "https://bedrock-mantle.eu-west-1.api.aws/openai/v1/chat/completions",
         BedrockOpenAIEndpoint(
             bedrock_region="eu-west-1",
+            client="mantle",
+            openai_base_url="https://bedrock-mantle.eu-west-1.api.aws/openai/v1",
+        ),
+    ),
+    (
+        "https://bedrock-runtime.eu-west-1.amazonaws.com/openai/v1/chat/completions",
+        BedrockOpenAIEndpoint(
+            bedrock_region="eu-west-1",
+            client="runtime",
+            openai_base_url="https://bedrock-runtime.eu-west-1.amazonaws.com/openai/v1",
+        ),
+    ),
+    # A host merely starting with the Bedrock one is not Bedrock.
+    (
+        "https://bedrock-runtime.eu-west-1.amazonaws.com.example.com/openai/v1/chat/completions",
+        OpenAIEndpoint(
+            openai_base_url="https://bedrock-runtime.eu-west-1.amazonaws.com.example.com/openai/v1",
         ),
     ),
 ]
@@ -215,6 +244,26 @@ def test_responses_parser(endpoint, parsed):
 def test_optional_chat_endpoint_parser(endpoint, parsed):
     result = chat_completions_optional_parser.parse(endpoint)
     assert result == parsed
+
+
+@pytest.mark.parametrize(
+    "client, expected_type",
+    [("mantle", AsyncBedrockOpenAI), ("runtime", AsyncOpenAI)],
+)
+def test_bedrock_endpoint_client_routing(
+    monkeypatch: pytest.MonkeyPatch, client, expected_type
+):
+    monkeypatch.setattr(
+        parsers, "provide_token", lambda *args, **kwargs: "bedrock-api-key"
+    )
+
+    endpoint = BedrockOpenAIEndpoint(
+        bedrock_region="us-east-1",
+        client=client,
+        openai_base_url="https://bedrock.example.com/openai/v1",
+    )
+
+    assert type(endpoint.get_client({})) is expected_type
 
 
 OPENAI_VIDEO_API_CASES = [


### PR DESCRIPTION
### Description of changes

Adds support for OpenAI models served by the Bedrock Runtime endpoint (`https://bedrock-runtime.${AWS_REGION}.amazonaws.com/openai/v1/...`), alongside the Bedrock Mantle endpoint already supported.

`BedrockOpenAIEndpoint` now carries the recognized `client` kind (`mantle` or `runtime`) and the upstream base URL, and `get_client` dispatches on it:

- **`mantle`** - `AsyncBedrockOpenAI`, unchanged.
- **`runtime`** - a vanilla `AsyncOpenAI` pointed at the upstream base URL, authenticated with a short-lived Bedrock bearer token minted via `aws-bedrock-token-generator` (new dependency).

The token is signed with the credentials the auth layer already resolves, so all four authentication options documented for Bedrock keep working for the new endpoint:

1. An upstream `key` is a Bedrock API key, i.e. already a bearer token - it is used as-is and no token is minted.
2. Otherwise the resolved AWS credentials (per-upstream `extra_data`, `AWS_*` environment variables, or an assumed role) are passed to the token generator through a `CredentialProvider`.
3. When nothing is configured, the generator falls back to the default AWS credential chain.